### PR TITLE
Add admx and adml files checking via admx-lint

### DIFF
--- a/.gear/admx-basealt.spec
+++ b/.gear/admx-basealt.spec
@@ -10,6 +10,8 @@ Group: System/Configuration/Other
 Url: https://github.com/altlinux/admx-basealt
 BuildArch: noarch
 
+BuildRequires: admx-lint
+
 Source0: %name-%version.tar
 
 %description
@@ -23,6 +25,11 @@ policy settings in the Group Policy Object Editor.
 %install
 mkdir -p %buildroot%_destdir
 cp -r ru-RU/ en-US/ BaseALT*.admx %buildroot%_destdir/
+
+%check
+for file in *.admx *-*/*.adml; do
+    admx-lint --input_file "$file"
+done
 
 %files
 %dir %_destdir


### PR DESCRIPTION
Let's start to use admx-lint:
https://github.com/altlinux/admx-lint/