### PR TITLE
Gsettings for windows manager Marco

### DIFF
--- a/BaseALT.admx
+++ b/BaseALT.admx
@@ -110,5 +110,11 @@
     <category name="ALT_Remote_Access_Vino_Gnome" displayName="$(string.ALT_Remote_Access_Vino_Gnome)" explainText="$(string.ALT_Remote_Access_Vino_Gnome_Help)">
       <parentCategory ref="ALT_System" />
     </category>
+    <category name="ALT_Windows_Manager_Marco" displayName="$(string.ALT_Windows_Manager_Marco)" explainText="$(string.ALT_Windows_Manager_Marco_Help)">
+      <parentCategory ref="ALT_Settings_Mate" />
+    </category>
+    <category name="ALT_Windows_Manager_Marco_Keyboard" displayName="$(string.ALT_Windows_Manager_Marco_Keyboard)" explainText="$(string.ALT_Windows_Manager_Marco_Keyboard_Help)">
+      <parentCategory ref="ALT_Windows_Manager_Marco" />
+    </category>
   </categories>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -1525,5 +1525,377 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneralActionMiddleClickTitlebarUser" class="User"
+        displayName="$(string.org-mate-marco-general-action-middle-click-titlebar)"
+        explainText="$(string.org-mate-marco-general-action-middle-click-titlebar_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralActionMiddleClickTitlebarUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter" required="true" valueName="org.mate.Marco.general.action-middle-click-titlebar">
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_shade)">
+            <value>
+              <string>toggle shade</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_maximize)">
+            <value>
+              <string>toggle maximize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_horizontally)">
+            <value>
+              <string>toggle maximize horizontally</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_vertically)">
+            <value>
+              <string>toggle maximize vertically</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-minimize)">
+            <value>
+              <string>minimize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-lower)">
+            <value>
+              <string>lower</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-menu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-last)">
+            <value>
+              <string>last</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralActionMiddleClickTitlebarMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-action-middle-click-titlebar)"
+        explainText="$(string.org-mate-marco-general-action-middle-click-titlebar_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralActionMiddleClickTitlebarMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter" required="true" valueName="org.mate.Marco.general.action-middle-click-titlebar">
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_shade)">
+            <value>
+              <string>toggle shade</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_maximize)">
+            <value>
+              <string>toggle maximize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_horizontally)">
+            <value>
+              <string>toggle maximize horizontally</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_vertically)">
+            <value>
+              <string>toggle maximize vertically</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-minimize)">
+            <value>
+              <string>minimize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-lower)">
+            <value>
+              <string>lower</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-menu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-middle-click-titlebar-last)">
+            <value>
+              <string>last</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.action-middle-click-titlebar">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralActionRightClickTitlebarUser" class="User"
+        displayName="$(string.org-mate-marco-general-action-right-click-titlebar)"
+        explainText="$(string.org-mate-marco-general-action-right-click-titlebar_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralActionRightClickTitlebarUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralActionRightClickTitlebar_setter" required="true" valueName="org.mate.Marco.general.action-right-click-titlebar">
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_shade)">
+            <value>
+              <string>toggle shade</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_maximize)">
+            <value>
+              <string>toggle maximize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_maximize_horizontally)">
+            <value>
+              <string>toggle maximize horizontally</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_maximize_vertically)">
+            <value>
+              <string>toggle maximize vertically</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-minimize)">
+            <value>
+              <string>minimize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-lower)">
+            <value>
+              <string>lower</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-menu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-last)">
+            <value>
+              <string>last</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralActionRightClickTitlebarMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-action-right-click-titlebar)"
+        explainText="$(string.org-mate-marco-general-action-right-click-titlebar_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralActionRightClickTitlebarMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralActionRightClickTitlebar_setter" required="true" valueName="org.mate.Marco.general.action-right-click-titlebar">
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_shade)">
+            <value>
+              <string>toggle shade</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_maximize)">
+            <value>
+              <string>toggle maximize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_maximize_horizontally)">
+            <value>
+              <string>toggle maximize horizontally</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-toggle_maximize_vertically)">
+            <value>
+              <string>toggle maximize vertically</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-minimize)">
+            <value>
+              <string>minimize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-lower)">
+            <value>
+              <string>lower</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-menu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-right-click-titlebar-last)">
+            <value>
+              <string>last</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralActionRightClickTitlebar_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.action-right-click-titlebar">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralActionDoubleClickTitlebarUser" class="User"
+        displayName="$(string.org-mate-marco-general-action-double-click-titlebar)"
+        explainText="$(string.org-mate-marco-general-action-double-click-titlebar_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralActionDoubleClickTitlebarUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter" required="true" valueName="org.mate.Marco.general.action-double-click-titlebar">
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_shade)">
+            <value>
+              <string>toggle shade</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_maximize)">
+            <value>
+              <string>toggle maximize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_maximize_horizontally)">
+            <value>
+              <string>toggle maximize horizontally</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_maximize_vertically)">
+            <value>
+              <string>toggle maximize vertically</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-minimize)">
+            <value>
+              <string>minimize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-lower)">
+            <value>
+              <string>lower</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-menu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-last)">
+            <value>
+              <string>last</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralActionDoubleClickTitlebarMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-action-double-click-titlebar)"
+        explainText="$(string.org-mate-marco-general-action-double-click-titlebar_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralActionDoubleClickTitlebarMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter" required="true" valueName="org.mate.Marco.general.action-double-click-titlebar">
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_shade)">
+            <value>
+              <string>toggle shade</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_maximize)">
+            <value>
+              <string>toggle maximize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_maximize_horizontally)">
+            <value>
+              <string>toggle maximize horizontally</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-toggle_maximize_vertically)">
+            <value>
+              <string>toggle maximize vertically</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-minimize)">
+            <value>
+              <string>minimize</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-none)">
+            <value>
+              <string>none</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-lower)">
+            <value>
+              <string>lower</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-menu)">
+            <value>
+              <string>menu</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-action-double-click-titlebar-last)">
+            <value>
+              <string>last</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.action-double-click-titlebar">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -2066,5 +2066,78 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneralCompositingFastAltTabUser" class="User"
+        displayName="$(string.org-mate-marco-general-compositing-fast-alt-tab)"
+        explainText="$(string.org-mate-marco-general-compositing-fast-alt-tab_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.compositing-fast-alt-tab">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralCompositingFastAltTabMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-compositing-fast-alt-tab)"
+        explainText="$(string.org-mate-marco-general-compositing-fast-alt-tab_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.compositing-fast-alt-tab"
+        presentation="$(presentation.OrgMateMarcoGeneralCompositingFastAltTabMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralCompositingFastAltTab_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.compositing-fast-alt-tab">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAutoRaiseDelayUser" class="User"
+        displayName="$(string.org-mate-marco-general-auto-raise-delay)"
+        explainText="$(string.org-mate-marco-general-auto-raise-delay_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralAutoRaiseDelayUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralAutoRaiseDelay_setter" valueName="org.mate.Marco.general.auto-raise-delay" minValue="1" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAutoRaiseDelayMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-auto-raise-delay)"
+        explainText="$(string.org-mate-marco-general-auto-raise-delay_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralAutoRaiseDelayMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralAutoRaiseDelay_setter" valueName="org.mate.Marco.general.auto-raise-delay" minValue="1" />
+        <boolean id="OrgMateMarcoGeneralAutoRaiseDelay_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.auto-raise-delay">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -1115,5 +1115,142 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneraButtonLayoutUser" class="User"
+        displayName="$(string.org-mate-marco-button-layout)"
+        explainText="$(string.org-mate-marco-button-layout_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneraButtonLayoutUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <text id="OrgMateMarcoGeneraButtonLayout_setter" valueName="org.mate.Marco.general.button-layout" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneraButtonLayoutMachine" class="Machine"
+        displayName="$(string.org-mate-marco-button-layout)"
+        explainText="$(string.org-mate-marco-button-layout_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneraButtonLayoutMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <text id="OrgMateMarcoGeneraButtonLayout_setter" valueName="org.mate.Marco.general.button-layout" />
+        <boolean id="OrgMateMarcoGeneraButtonLayout_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.button-layout">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralWrapStyleUser" class="User"
+        displayName="$(string.org-mate-marco-general-wrap-style)"
+        explainText="$(string.org-mate-marco-general-wrap-style_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralWrapStyleUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralWrapStyle_setter" required="true" valueName="org.mate.Marco.general.wrap-style">
+          <item displayName="$(string.org-mate-Marco-general-wrap-style-no-wrap)">
+            <value>
+              <string>no wrap</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-Marco-general-wrap-style-classic)">
+            <value>
+              <string>classic</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-Marco-general-wrap-style-toroidal)">
+            <value>
+              <string>toroidal</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralWrapStyleMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-wrap-style)"
+        explainText="$(string.org-mate-marco-general-wrap-style_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralWrapStyleMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralWrapStyle_setter" required="true" valueName="org.mate.Marco.general.wrap-style">
+          <item displayName="$(string.org-mate-Marco-general-wrap-style-no-wrap)">
+            <value>
+              <string>no wrap</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-Marco-general-wrap-style-classic)">
+            <value>
+              <string>classic</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-Marco-general-wrap-style-toroidal)">
+            <value>
+              <string>toroidal</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralWrapStyle_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.wrap-style">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralShowTabBorderUser" class="User"
+        displayName="$(string.org-mate-marco-general-show-tab-border)"
+        explainText="$(string.org-mate-marco-general-show-tab-border_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.show-tab-border">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralShowTabBorderMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-show-tab-border)"
+        explainText="$(string.org-mate-marco-general-show-tab-border_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.show-tab-border"
+        presentation="$(presentation.OrgMateMarcoGeneralShowTabBorderMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralShowTabBorder_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.show-tab-border">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -1897,5 +1897,174 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneralThemeUser" class="User"
+        displayName="$(string.org-mate-marco-general-theme)"
+        explainText="$(string.org-mate-marco-general-theme_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralThemeUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <text id="OrgMateMarcoGeneralTheme_setter" valueName="org.mate.Marco.general.theme" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralThemeMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-theme)"
+        explainText="$(string.org-mate-marco-general-theme_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralThemeMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <text id="OrgMateMarcoGeneralTheme_setter" valueName="org.mate.Marco.general.theme" />
+        <boolean id="OrgMateMarcoGeneralTheme_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.theme">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralTitlebarFontUser" class="User"
+        displayName="$(string.org-mate-marco-general-titlebar-font)"
+        explainText="$(string.org-mate-marco-general-titlebar-font_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralTitlebarFont-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <text id="OrgMateMarcoGeneralTheme_setter" valueName="org.mate.Marco.general.titlebar-font" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralTitlebarFontMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-titlebar-font)"
+        explainText="$(string.org-mate-marco-general-titlebar-font_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralTitlebarFontMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <text id="OrgMateMarcoGeneralTitlebarFont_setter" valueName="org.mate.Marco.general.titlebar-font" />
+        <boolean id="OrgMateMarcoGeneralTitlebarFont_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.titlebar-font">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralFocusModeUser" class="User"
+        displayName="$(string.org-mate-marco-general-focus-mode)"
+        explainText="$(string.org-mate-marco-general-focus-mode_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralFocusModeUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralFocusMode_setter" required="true" valueName="org.mate.Marco.general.focus-mode">
+          <item displayName="$(string.org-mate-marco-general-focus-mode-click)">
+            <value>
+              <string>click</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-focus-mode-sloppy)">
+            <value>
+              <string>sloppy</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-focus-mode-mouse)">
+            <value>
+              <string>mouse</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralFocusModeMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-focus-mode)"
+        explainText="$(string.org-mate-marco-general-focus-mode_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralFocusModeMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralFocusMode_setter" required="true" valueName="org.mate.Marco.general.focus-mode">
+          <item displayName="$(string.org-mate-marco-general-focus-mode-click)">
+            <value>
+              <string>click</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-focus-mode-sloppy)">
+            <value>
+              <string>sloppy</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-focus-mode-mouse)">
+            <value>
+              <string>mouse</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralFocusMode_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.focus-mode">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralTitlebarUsesSystemFontUser" class="User"
+        displayName="$(string.org-mate-marco-general-titlebar-uses-system-font)"
+        explainText="$(string.org-mate-marco-general-titlebar-uses-system-font_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.titlebar-uses-system-font">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralTitlebarUsesSystemFontMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-titlebar-uses-system-font)"
+        explainText="$(string.org-mate-marco-general-titlebar-uses-system-font_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.titlebar-uses-system-font"
+        presentation="$(presentation.OrgMateMarcoGeneralTitlebarUsesSystemFontMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralTitlebarUsesSystemFont_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.titlebar-uses-system-font">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -2244,5 +2244,110 @@
       </elements>
     </policy>
 
+    <policy name="OrgMatePeripheralsKeyboardDelayUser" class="User"
+        displayName="$(string.org-mate-peripherals-keyboard-delay)"
+        explainText="$(string.org-mate-peripherals-keyboard-delay_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMatePeripheralsKeyboardDelayUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco_Keyboard" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMatePeripheralsKeyboardDelay_setter" valueName="org.mate.peripherals-keyboard.delay" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMatePeripheralsKeyboardDelayMachine" class="Machine"
+        displayName="$(string.org-mate-peripherals-keyboard-delay)"
+        explainText="$(string.org-mate-peripherals-keyboard-delay_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMatePeripheralsKeyboardDelayMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco_Keyboard" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMatePeripheralsKeyboardDelay_setter" valueName="org.mate.peripherals-keyboard.delay"/>
+        <boolean id="OrgMatePeripheralsKeyboardDelay_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.peripherals-keyboard.delay">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMatePeripheralsKeyboardRepeatUser" class="User"
+        displayName="$(string.org-mate-peripherals-keyboard-repeat)"
+        explainText="$(string.org-mate-peripherals-keyboard-repeat_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.peripherals-keyboard.repeat">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco_Keyboard" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMatePeripheralsKeyboardRepeatMachine" class="Machine"
+        displayName="$(string.org-mate-peripherals-keyboard-repeat)"
+        explainText="$(string.org-mate-peripherals-keyboard-repeat_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.peripherals-keyboard.repeat"
+        presentation="$(presentation.OrgMatePeripheralsKeyboardRepeatMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco_Keyboard" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMatePeripheralsKeyboardRepeat_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.peripherals-keyboard.repeat">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMatePeripheralsKeyboardRateUser" class="User"
+        displayName="$(string.org-mate-peripherals-keyboard-rate)"
+        explainText="$(string.org-mate-peripherals-keyboard-rate_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMatePeripheralsKeyboardRateUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco_Keyboard" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMatePeripheralsKeyboardRate_setter" valueName="org.mate.peripherals-keyboard.rate" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMatePeripheralsKeyboardRateMachine" class="Machine"
+        displayName="$(string.org-mate-peripherals-keyboard-rate)"
+        explainText="$(string.org-mate-peripherals-keyboard-rate_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMatePeripheralsKeyboardRateMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco_Keyboard" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMatePeripheralsKeyboardRate_setter" valueName="org.mate.peripherals-keyboard.rate" />
+        <boolean id="OrgMatePeripheralsKeyboardRate_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.peripherals-keyboard.rate">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -1252,5 +1252,141 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneralAllowTopTilingUser" class="User"
+        displayName="$(string.org-mate-marco-general-allow-top-tiling)"
+        explainText="$(string.org-mate-marco-general-allow-top-tiling_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.allow-top-tiling">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAllowTopTilingMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-allow-top-tiling)"
+        explainText="$(string.org-mate-marco-general-allow-top-tiling_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.allow-top-tiling"
+        presentation="$(presentation.OrgMateMarcoGeneralAllowTopTilingMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralAllowTopTilingMachine_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.allow-top-tiling">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralFocusNewWindowsUser" class="User"
+        displayName="$(string.org-mate-marco-general-focus-new-windows)"
+        explainText="$(string.org-mate-marco-general-focus-new-windows_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralFocusNewWindowsUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralFocusNewWindows_setter" required="true" valueName="org.mate.Marco.general.focus-new-windows">
+          <item displayName="$(string.org-mate-Marco-general-focus-new-windows-smart)">
+            <value>
+              <string>smart</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-Marco-general-focus-new-windows-strict)">
+            <value>
+              <string>strict</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralFocusNewWindowsMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-focus-new-windows)"
+        explainText="$(string.org-mate-marco-general-focus-new-windows_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralFocusNewWindowsMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralFocusNewWindows_setter" required="true" valueName="org.mate.Marco.general.focus-new-windows">
+          <item displayName="$(string.org-mate-Marco-general-focus-new-windows-smart)">
+            <value>
+              <string>smart</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-Marco-general-focus-new-windows-strict)">
+            <value>
+              <string>strict</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralFocusNewWindows_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.focus-new-windows">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAllowTilingUser" class="User"
+        displayName="$(string.org-mate-marco-general-allow-tiling)"
+        explainText="$(string.org-mate-marco-general-allow-tiling_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.allow-tiling">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAllowTilingMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-allow-tiling)"
+        explainText="$(string.org-mate-marco-general-allow-tiling_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.allow-tiling"
+        presentation="$(presentation.OrgMateMarcoGeneralAllowTilingMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralAllowTiling_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.allow-tiling">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -1388,5 +1388,142 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneralNumWorkspacesUser" class="User"
+        displayName="$(string.org-mate-marco-general-num-workspaces)"
+        explainText="$(string.org-mate-marco-general-num-workspaces_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralNumWorkspacesUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralNumWorkspaces_setter" valueName="org.mate.Marco.general.num-workspaces" minValue="1" maxValue="36" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralNumWorkspacesMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-num-workspaces)"
+        explainText="$(string.org-mate-marco-general-num-workspaces_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralNumWorkspacesMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralNumWorkspaces_setter" valueName="org.mate.Marco.general.num-workspaces" minValue="1" maxValue="36" />
+        <boolean id="OrgMateMarcoGeneralNumWorkspaces_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.num-workspaces">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralPlacementModeUser" class="User"
+        displayName="$(string.org-mate-marco-general-placement-mode)"
+        explainText="$(string.org-mate-marco-general-placement-mode_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralPlacementModeUser-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralPlacementMode_setter" required="true" valueName="org.mate.Marco.general.placement-mode">
+          <item displayName="$(string.org-mate-marco-general-placement-mode-automatic)">
+            <value>
+              <string>automatic</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-placement-mode-pointer)">
+            <value>
+              <string>pointer</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-placement-mode-manual)">
+            <value>
+              <string>manual</string>
+            </value>
+          </item>
+        </enum>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralPlacementModeMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-placement-mode)"
+        explainText="$(string.org-mate-marco-general-placement-mode_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralPlacementModeMachine-pr)" >
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <elements>
+        <enum id="OrgMateMarcoGeneralPlacementMode_setter" required="true" valueName="org.mate.Marco.general.placement-mode">
+          <item displayName="$(string.org-mate-marco-general-placement-mode-automatic)">
+            <value>
+              <string>automatic</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-placement-mode-pointer)">
+            <value>
+              <string>pointer</string>
+            </value>
+          </item>
+          <item displayName="$(string.org-mate-marco-general-placement-mode-manual)">
+            <value>
+              <string>manual</string>
+            </value>
+          </item>
+        </enum>
+        <boolean id="OrgMateMarcoGeneralPlacementMode_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.placement-mode">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAutoRaiseUser" class="User"
+        displayName="$(string.org-mate-marco-general-auto-raise)"
+        explainText="$(string.org-mate-marco-general-auto-raise_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.auto-raise">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAutoRaiseMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-auto-raise)"
+        explainText="$(string.org-mate-marco-general-auto-raise_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.auto-raise"
+        presentation="$(presentation.OrgMateMarcoGeneralAutoRaiseMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralAutoRaise_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.auto-raise">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/BaseALTGsettings.admx
+++ b/BaseALTGsettings.admx
@@ -2139,5 +2139,110 @@
       </elements>
     </policy>
 
+    <policy name="OrgMateMarcoGeneralCenterNewWindowsUser" class="User"
+        displayName="$(string.org-mate-marco-general-center-new-windows)"
+        explainText="$(string.org-mate-marco-general-center-new-windows_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.center-new-windows">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralCenterNewWindowsMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-center-new-windows)"
+        explainText="$(string.org-mate-marco-general-center-new-windows_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        valueName="org.mate.Marco.general.center-new-windows"
+        presentation="$(presentation.OrgMateMarcoGeneralCenterNewWindowsMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP9" />
+      <enabledValue>
+        <decimal value="1" />
+      </enabledValue>
+      <disabledValue>
+        <decimal value="0" />
+      </disabledValue>
+      <elements>
+        <boolean id="OrgMateMarcoGeneralCenterNewWindows_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.center-new-windows">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralIconSizeUser" class="User"
+        displayName="$(string.org-mate-marco-general-icon-size)"
+        explainText="$(string.org-mate-marco-general-icon-size_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralIconSizeUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP10" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralIconSize_setter" valueName="org.mate.Marco.general.icon-size" minValue="8" maxValue="256" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralIconSizeMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-icon-size)"
+        explainText="$(string.org-mate-marco-general-icon-size_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralIconSizeMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP10" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralIconSize_setter" valueName="org.mate.Marco.general.icon-size" minValue="8" maxValue="256" />
+        <boolean id="OrgMateMarcoGeneralIconSize_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.icon-size">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAltTabMaxColumnsUser" class="User"
+        displayName="$(string.org-mate-marco-general-alt-tab-max-columns)"
+        explainText="$(string.org-mate-marco-general-alt-tab-max-columns_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralAltTabMaxColumnsUser-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP10" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralAltTabMaxColumns_setter" valueName="org.mate.Marco.general.alt-tab-max-columns" minValue="1" maxValue="64" />
+      </elements>
+    </policy>
+
+    <policy name="OrgMateMarcoGeneralAltTabMaxColumnsMachine" class="Machine"
+        displayName="$(string.org-mate-marco-general-alt-tab-max-columns)"
+        explainText="$(string.org-mate-marco-general-alt-tab-max-columns_help)"
+        key="Software\BaseALT\Policies\gsettings"
+        presentation="$(presentation.OrgMateMarcoGeneralAltTabMaxColumnsMachine-pr)">
+      <parentCategory ref="system:ALT_Windows_Manager_Marco" />
+      <supportedOn ref="system:SUPPORTED_AltP10" />
+      <elements>
+        <decimal id="OrgMateMarcoGeneralAltTabMaxColumns_setter" valueName="org.mate.Marco.general.alt-tab-max-columns" minValue="1" maxValue="64" />
+        <boolean id="OrgMateMarcoGeneralAltTabMaxColumns_setter_blocker" key="Software\BaseALT\Policies\GSettingsLocks" valueName="org.mate.Marco.general.alt-tab-max-columns">
+          <trueValue>
+            <decimal value="1" />
+          </trueValue>
+          <falseValue>
+            <decimal value="0" />
+          </falseValue>
+        </boolean>
+      </elements>
+    </policy>
+
   </policies>
 </policyDefinitions>

--- a/en-US/basealt.adml
+++ b/en-US/basealt.adml
@@ -52,6 +52,10 @@
       <string id="ALT_User_Restrictions_Mate_Help">Resctrictions on user actions</string>
       <string id="ALT_Remote_Access_Vino_Gnome">Remote access via Vino</string>
       <string id="ALT_Remote_Access_Vino_Gnome_Help">Remote access via Vino settings</string>
+      <string id="ALT_Windows_Manager_Marco">Windows manager Marco</string>
+      <string id="ALT_ALT_Windows_Manager_Marco_Help">Windows manager Marco settings</string>
+      <string id="ALT_Windows_Manager_Marco_Keyboard">Keyboard settings</string>
+      <string id="ALT_Windows_Manager_Marco_Keyboard_Help">Keyboard settings</string>
     </stringTable>
   </resources>
 </policyDefinitionResources>

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -111,6 +111,17 @@
       <string id="org-mate-marco-general-show-tab-border">Show window border</string>
       <string id="org-mate-marco-general-show-tab-border_help">Set this to false to disable border of preselected window while performing tab switching.</string>
 
+      <string id="org-mate-marco-general-allow-top-tiling">Allow top tiling</string>
+      <string id="org-mate-marco-general-allow-top-tiling_help">If enabled, drag-dropping a window to the top of the screen will maximize it. Only works when allow-tiling is enabled.</string>
+
+      <string id="org-mate-marco-general-focus-new-windows">Switch focus to a new window</string>
+      <string id="org-mate-marco-general-focus-new-windows_help">This option provides additional control over how newly created windows get focus. It has two possible values; "smart" applies the user's normal focus mode, and "strict" results in windows started from a terminal not being given focus.</string>
+      <string id="org-mate-Marco-general-focus-new-windows-smart">smart</string>
+      <string id="org-mate-Marco-general-focus-new-windows-strict">strict</string>
+
+      <string id="org-mate-marco-general-allow-tiling">Resizing when drag-dropping</string>
+      <string id="org-mate-marco-general-allow-tiling_help">If enabled, dropping windows on screen edges maximizes them vertically and resizes them horizontally to cover half of the available area. Drag-dropping to the top maximizes the window if allow-top-tiling is enabled.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -352,6 +363,26 @@
 
       <presentation id="OrgMateMarcoGeneralShowTabBorderMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralShowTabBorder_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralAllowTopTilingMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralAllowTopTilingMachine_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusNewWindowsUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusNewWindows_setter">focus transfer:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusNewWindowsMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusNewWindows_setter">focus transfer:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralFocusNewWindows_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralAllowTilingMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralAllowTiling_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -184,6 +184,12 @@
 
       <string id="org-mate-marco-general-titlebar-uses-system-font">System font in the titlebar</string>
       <string id="org-mate-marco-general-titlebar-uses-system-font_help">When enabled, the system font will be used in the window titlebar.</string>
+
+      <string id="org-mate-marco-general-compositing-fast-alt-tab">Thumbnails when switching windows</string>
+      <string id="org-mate-marco-general-compositing-fast-alt-tab_help">If set to true, no window thumbnails will be displayed in the alt-tab popup window when the compositing manager is enabled. Application icons will be displayed instead.</string>
+
+      <string id="org-mate-marco-general-auto-raise-delay">Auto raise delay</string>
+      <string id="org-mate-marco-general-auto-raise-delay_help">The time delay before raising a window if auto_raise is set to true. The delay is given in milliseconds.</string>
     </stringTable>
 
     <presentationTable>
@@ -591,6 +597,21 @@ last - repeat last action</text>
 
       <presentation id="OrgMateMarcoGeneralTitlebarUsesSystemFontMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralTitlebarUsesSystemFont_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralCompositingFastAltTabMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralCompositingFastAltTab_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAutoRaiseDelayUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter" defaultValue="500">Milliseconds:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAutoRaiseDelayMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter" defaultValue="500">Milliseconds:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -133,6 +133,42 @@
 
       <string id="org-mate-marco-general-auto-raise">Raise the window in focus</string>
       <string id="org-mate-marco-general-auto-raise_help">If set to true, and the focus mode is either "sloppy" or "mouse" then the focused window will be automatically raised after a delay specified by the auto_raise_delay key. This is not related to clicking on a window to raise it, nor to entering a window during drag-and-drop.</string>
+
+      <string id="org-mate-marco-general-action-middle-click-titlebar">Action by the middle button</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar_help">Set the action performed by pressing the middle mouse button.</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_shade">toggle_shade</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_maximize">toggle_maximize</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_horizontally">toggle_maximize_horizontally</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_vertically">toggle_maximize_vertically</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-minimize">minimize</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-none">none</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-lower">lower</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-menu">menu</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-last">last</string>
+
+      <string id="org-mate-marco-general-action-right-click-titlebar">Action by the right button</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar_help">Set the action performed by pressing the right button on the header.</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_shade">toggle_shade</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_maximize">toggle_maximize</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_maximize_horizontally">toggle_maximize_horizontally</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_maximize_vertically">toggle_maximize_vertically</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-minimize">minimize</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-none">none</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-lower">lower</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-menu">menu</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-last">last</string>
+
+      <string id="org-mate-marco-general-action-double-click-titlebar">Action by the double click</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar_help">Set the action performed by double-click the left button on the header.</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_shade">toggle_shade</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_maximize">toggle_maximize</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_maximize_horizontally">toggle_maximize_horizontally</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_maximize_vertically">toggle_maximize_vertically</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-minimize">minimize</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-none">none</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-lower">lower</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-menu">menu</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-last">last</string>
     </stringTable>
 
     <presentationTable>
@@ -419,6 +455,84 @@
 
       <presentation id="OrgMateMarcoGeneralAutoRaiseMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralAutoRaise_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralActionMiddleClickTitlebarUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter">Action:</dropdownList>
+        <text>toggle_shade - will shade/unshade the window
+toggle_maximize - will maximize/unmaximize the window
+toggle_maximize_horizontally - which will maximize/unmaximize the window horizontally
+toggle_maximize_vertically - which will maximize/unmaximize the window vertically
+none - nothing
+lower - will put the window behind all the others
+menu - will display the window menu
+last - repeat last action</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralActionMiddleClickTitlebarMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter">Action:</dropdownList>
+<text>toggle_shade - will shade/unshade the window
+toggle_maximize - will maximize/unmaximize the window
+toggle_maximize_horizontally - which will maximize/unmaximize the window horizontally
+toggle_maximize_vertically - which will maximize/unmaximize the window vertically
+none - nothing
+lower - will put the window behind all the others
+menu - will display the window menu
+last - repeat last action</text>
+        <checkBox refId="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralActionRightClickTitlebarUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionRightClickTitlebar_setter">Action:</dropdownList>
+<text>toggle_shade - will shade/unshade the window
+toggle_maximize - will maximize/unmaximize the window
+toggle_maximize_horizontally - which will maximize/unmaximize the window horizontally
+toggle_maximize_vertically - which will maximize/unmaximize the window vertically
+none - nothing
+lower - will put the window behind all the others
+menu - will display the window menu
+last - repeat last action</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralActionRightClickTitlebarMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionRightClickTitlebar_setter">Action:</dropdownList>
+<text>toggle_shade - will shade/unshade the window
+toggle_maximize - will maximize/unmaximize the window
+toggle_maximize_horizontally - which will maximize/unmaximize the window horizontally
+toggle_maximize_vertically - which will maximize/unmaximize the window vertically
+none - nothing
+lower - will put the window behind all the others
+menu - will display the window menu
+last - repeat last action</text>
+        <checkBox refId="OrgMateMarcoGeneralActionRightClickTitlebar_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralActionDoubleClickTitlebarUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter">Action:</dropdownList>
+<text>toggle_shade - will shade/unshade the window
+toggle_maximize - will maximize/unmaximize the window
+toggle_maximize_horizontally - which will maximize/unmaximize the window horizontally
+toggle_maximize_vertically - which will maximize/unmaximize the window vertically
+none - nothing
+lower - will put the window behind all the others
+menu - will display the window menu
+last - repeat last action</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralActionDoubleClickTitlebarMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter">Action:</dropdownList>
+<text>toggle_shade - will shade/unshade the window
+toggle_maximize - will maximize/unmaximize the window
+toggle_maximize_horizontally - which will maximize/unmaximize the window horizontally
+toggle_maximize_vertically - which will maximize/unmaximize the window vertically
+none - nothing
+lower - will put the window behind all the others
+menu - will display the window menu
+last - repeat last action</text>
+        <checkBox refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -169,6 +169,21 @@
       <string id="org-mate-marco-general-action-double-click-titlebar-lower">lower</string>
       <string id="org-mate-marco-general-action-double-click-titlebar-menu">menu</string>
       <string id="org-mate-marco-general-action-double-click-titlebar-last">last</string>
+
+      <string id="org-mate-marco-general-theme">Theme</string>
+      <string id="org-mate-marco-general-theme_help">The theme determines the appearance of window borders, titlebar, and so forth.</string>
+
+      <string id="org-mate-marco-general-titlebar-font">Titlebar font</string>
+      <string id="org-mate-marco-general-titlebar-font_help">Sets the font of titlebar.</string>
+
+      <string id="org-mate-marco-general-focus-mode">Window focus switch mode</string>
+      <string id="org-mate-marco-general-focus-mode_help">Set the window focus switching mode.</string>
+      <string id="org-mate-marco-general-focus-mode-click">click</string>
+      <string id="org-mate-marco-general-focus-mode-sloppy">sloppy</string>
+      <string id="org-mate-marco-general-focus-mode-mouse">mouse</string>
+
+      <string id="org-mate-marco-general-titlebar-uses-system-font">System font in the titlebar</string>
+      <string id="org-mate-marco-general-titlebar-uses-system-font_help">When enabled, the system font will be used in the window titlebar.</string>
     </stringTable>
 
     <presentationTable>
@@ -533,6 +548,49 @@ lower - will put the window behind all the others
 menu - will display the window menu
 last - repeat last action</text>
         <checkBox refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralThemeUser-pr">
+        <textBox refId="OrgMateMarcoGeneralTheme_setter">
+          <label>Theme:</label>
+        </textBox>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralThemeMachine-pr">
+        <textBox refId="OrgMateMarcoGeneralTheme_setter">
+          <label>Theme:</label>
+        </textBox>
+        <checkBox refId="OrgMateMarcoGeneralTheme_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralTitlebarFont-pr">
+        <textBox refId="OrgMateMarcoGeneralTheme_setter">
+          <label>Тема:</label>
+        </textBox>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralTitlebarFontMachine-pr">
+        <textBox refId="OrgMateMarcoGeneralTitlebarFont_setter">
+          <label>Тема:</label>
+        </textBox>
+        <checkBox refId="OrgMateMarcoGeneralTitlebarFont_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusModeUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusMode_setter">Window focus switching mode:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusModeMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusMode_setter">Window focus switching mode:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralFocusMode_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralTitlebarUsesSystemFontMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralTitlebarUsesSystemFont_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -99,6 +99,18 @@
       <string id="org-gnome-vino-vnc-password">Password for remote access</string>
       <string id="org-gnome-vino-vnc-password_help">The password which the remote user will be prompted for if the "vnc" authentication method is used. The password specified by the key is base64 encoded.  The special value of 'keyring' (which is not valid base64) means that the password is stored in the GNOME keyring.</string>
 
+      <string id="org-mate-marco-button-layout">Window title Icons</string>
+      <string id="org-mate-marco-button-layout_help">Settings for the location of icons in the window title. The separator of the right and left halves is a colon. For example, the line 'menu:minimize,maximize,spacer,close' has the window menu icon on the left, and on the right the icons collapse, open, close the window.</string>
+
+      <string id="org-mate-marco-general-wrap-style">Switch workspaces</string>
+      <string id="org-mate-marco-general-wrap-style_help">The wrap style is used to determine how to switch from one workspace to another at the border of the workspace switcher. When set to "no wrap", nothing will happen if you try to switch to a workspace past the border of the workspace switcher. If set to "classic", the old marco behavior is used: the end of one row leads to the beginning of the next and the end of a column leads to the beginning of the next. If set to "toroidal", workspaces are connected like a doughnut: the end of each row leads to its own beginning and the end of each column leads to its own beginning.</string>
+      <string id="org-mate-Marco-general-wrap-style-no-wrap">no wrap</string>
+      <string id="org-mate-Marco-general-wrap-style-classic">classic</string>
+      <string id="org-mate-Marco-general-wrap-style-toroidal">toroidal</string>
+
+      <string id="org-mate-marco-general-show-tab-border">Show window border</string>
+      <string id="org-mate-marco-general-show-tab-border_help">Set this to false to disable border of preselected window while performing tab switching.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -311,6 +323,35 @@
           <label>Password:</label>
         </textBox>
         <checkBox refId="OrgGnomeVinoVncPassword_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneraButtonLayoutUser-pr">
+        <textBox refId="OrgMateMarcoGeneraButtonLayout_setter">
+          <label></label>
+        </textBox>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneraButtonLayoutMachine-pr">
+        <textBox refId="OrgMateMarcoGeneraButtonLayout_setter">
+          <label></label>
+        </textBox>
+        <checkBox refId="OrgMateMarcoGeneraButtonLayout_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralWrapStyleUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralWrapStyle_setter">Method:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralWrapStyleMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralWrapStyle_setter">Method:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralWrapStyle_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralShowTabBorderMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralShowTabBorder_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -122,6 +122,17 @@
       <string id="org-mate-marco-general-allow-tiling">Resizing when drag-dropping</string>
       <string id="org-mate-marco-general-allow-tiling_help">If enabled, dropping windows on screen edges maximizes them vertically and resizes them horizontally to cover half of the available area. Drag-dropping to the top maximizes the window if allow-top-tiling is enabled.</string>
 
+      <string id="org-mate-marco-general-num-workspaces">Number of workspaces</string>
+      <string id="org-mate-marco-general-num-workspaces_help">Set the number of workspaces. The range of acceptable values is 1-36.</string>
+
+      <string id="org-mate-marco-general-placement-mode">Location of new windows</string>
+      <string id="org-mate-marco-general-placement-mode_help">Indicates how new windows are positioned. "automatic" means the system chooses a location automatically based on the space available on the desktop, or by a simple cascade if there is no space; "pointer" means that new windows are placed according to the mouse pointer position; "manual" means that the user must manually place the new window with the mouse or keyboard.</string>
+      <string id="org-mate-marco-general-placement-mode-automatic">automatic</string>
+      <string id="org-mate-marco-general-placement-mode-pointer">pointer</string>
+      <string id="org-mate-marco-general-placement-mode-manual">manual</string>
+
+      <string id="org-mate-marco-general-auto-raise">Raise the window in focus</string>
+      <string id="org-mate-marco-general-auto-raise_help">If set to true, and the focus mode is either "sloppy" or "mouse" then the focused window will be automatically raised after a delay specified by the auto_raise_delay key. This is not related to clicking on a window to raise it, nor to entering a window during drag-and-drop.</string>
     </stringTable>
 
     <presentationTable>
@@ -383,6 +394,31 @@
 
       <presentation id="OrgMateMarcoGeneralAllowTilingMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralAllowTiling_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralNumWorkspacesUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralNumWorkspaces_setter" defaultValue="2">Number of workspaces:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralNumWorkspacesMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralNumWorkspaces_setter" defaultValue="2">Number of workspaces:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralNumWorkspaces_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralPlacementModeUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralPlacementMode_setter">Location:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralPlacementModeMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralPlacementMode_setter">Location:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralPlacementMode_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralAutoRaiseMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralAutoRaise_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -199,6 +199,15 @@
 
       <string id="org-mate-marco-general-alt-tab-max-columns">Alt+Tab switching window size</string>
       <string id="org-mate-marco-general-alt-tab-max-columns_help">The popup Alt+Tab window will be expanded to fit up to these many entries per row.</string>
+
+      <string id="org-mate-peripherals-keyboard-delay">Delay before repeat</string>
+      <string id="org-mate-peripherals-keyboard-delay_help">The delay in milliseconds before repeating the pressed and held key.</string>
+
+      <string id="org-mate-peripherals-keyboard-repeat">Enable repeat</string>
+      <string id="org-mate-peripherals-keyboard-repeat_help">Enable repeat of the pressed and held key.</string>
+
+      <string id="org-mate-peripherals-keyboard-rate">Repeat rate</string>
+      <string id="org-mate-peripherals-keyboard-rate_help">Sets the repeat rate of the pressed and held key.</string>
     </stringTable>
 
     <presentationTable>
@@ -646,6 +655,31 @@ last - repeat last action</text>
         <presentation id="OrgMateMarcoGeneralAltTabMaxColumnsMachine-pr">
         <decimalTextBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter" defaultValue="5">Number of columns</decimalTextBox>
         <checkBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardDelayUser-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardDelay_setter">Delay:</decimalTextBox>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardDelayMachine-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardDelay_setter">Delay:</decimalTextBox>
+        <checkBox refId="OrgMatePeripheralsKeyboardDelay_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardRepeatMachine-pr">
+        <checkBox refId="OrgMatePeripheralsKeyboardRepeat_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardRateUser-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardRate_setter">Repeat rate:</decimalTextBox>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardRateMachine-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardRate_setter">Repeat rate:</decimalTextBox>
+        <checkBox refId="OrgMatePeripheralsKeyboardRate_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -190,6 +190,15 @@
 
       <string id="org-mate-marco-general-auto-raise-delay">Auto raise delay</string>
       <string id="org-mate-marco-general-auto-raise-delay_help">The time delay before raising a window if auto_raise is set to true. The delay is given in milliseconds.</string>
+
+      <string id="org-mate-marco-general-center-new-windows">Center new windows</string>
+      <string id="org-mate-marco-general-center-new-windows_help">If set to true, new windows are opened in the center of the screen. Otherwise, they are opened at the top left of the screen.</string>
+
+      <string id="org-mate-marco-general-icon-size">Icon size</string>
+      <string id="org-mate-marco-general-icon-size_help">Size of the application icons displayed in alt-tab popup window. The screen's scale factor is applied to this value.</string>
+
+      <string id="org-mate-marco-general-alt-tab-max-columns">Alt+Tab switching window size</string>
+      <string id="org-mate-marco-general-alt-tab-max-columns_help">The popup Alt+Tab window will be expanded to fit up to these many entries per row.</string>
     </stringTable>
 
     <presentationTable>
@@ -612,6 +621,31 @@ last - repeat last action</text>
         <presentation id="OrgMateMarcoGeneralAutoRaiseDelayMachine-pr">
         <decimalTextBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter" defaultValue="500">Milliseconds:</decimalTextBox>
         <checkBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralCenterNewWindowsMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralCenterNewWindows_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralIconSizeUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralIconSize_setter" defaultValue="48">Size:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralIconSizeMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralIconSize_setter" defaultValue="48">Size:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralIconSize_setter_blocker">lock</checkBox>
+        <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAltTabMaxColumnsUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter" defaultValue="5">Number of columns</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAltTabMaxColumnsMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter" defaultValue="5">Number of columns</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter_blocker">lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/ru-RU/basealt.adml
+++ b/ru-RU/basealt.adml
@@ -52,6 +52,10 @@
       <string id="ALT_User_Restrictions_Mate_Help">Ограничения действий пользователя</string>
       <string id="ALT_Remote_Access_Vino_Gnome">Удаленный доступ через Vino</string>
       <string id="ALT_Remote_Access_Vino_Gnome_Help">Настройки удаленного доступа через Vino</string>
+      <string id="ALT_Windows_Manager_Marco">Оконный менеджер Marco</string>
+      <string id="ALT_Windows_Manager_Marco_Help">Настройки оконного менеджера Marco</string>
+      <string id="ALT_Windows_Manager_Marco_Keyboard">Настройки клавиатуры</string>
+      <string id="ALT_Windows_Manager_Marco_Keyboard_Help">Настройки клавиатуры</string>
     </stringTable>
   </resources>
 </policyDefinitionResources>

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -99,6 +99,18 @@
       <string id="org-gnome-vino-vnc-password">Пароль для подключения</string>
       <string id="org-gnome-vino-vnc-password_help">Пароль, который удаленному пользователю будет предложено ввести, если используется метод аутентификации "vnc". Пароль, указанный ключом, закодирован в кодировке base64.</string>
 
+      <string id="org-mate-marco-button-layout">Иконки заголовка окна</string>
+      <string id="org-mate-marco-button-layout_help">Настройки расположения иконок в заголовке окна. Разделителем правой и левой половин является двоеточие. Например, строка 'menu:minimize,maximize,spacer,close' располагаем иконку меню окна слева, а справа иконки свернуть, распахнуть, закрыть окно.</string>
+
+      <string id="org-mate-marco-general-wrap-style">Переключение рабочих областей</string>
+      <string id="org-mate-marco-general-wrap-style_help">Настройки окна переключения рабочих областей</string>
+      <string id="org-mate-Marco-general-wrap-style-no-wrap">no wrap</string>
+      <string id="org-mate-Marco-general-wrap-style-classic">classic</string>
+      <string id="org-mate-Marco-general-wrap-style-toroidal">toroidal</string>
+
+      <string id="org-mate-marco-general-show-tab-border">Граница окна при переключении</string>
+      <string id="org-mate-marco-general-show-tab-border_help">Показывать ли границу окна при переключении с помощью Alt+Tab.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -311,6 +323,35 @@
           <label>Пароль:</label>
         </textBox>
         <checkBox refId="OrgGnomeVinoVncPassword_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+<presentation id="OrgMateMarcoGeneraButtonLayoutUser-pr">
+        <textBox refId="OrgMateMarcoGeneraButtonLayout_setter">
+          <label></label>
+        </textBox>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneraButtonLayoutMachine-pr">
+        <textBox refId="OrgMateMarcoGeneraButtonLayout_setter">
+          <label></label>
+        </textBox>
+        <checkBox refId="OrgMateMarcoGeneraButtonLayout_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralWrapStyleUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralWrapStyle_setter">Метод:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralWrapStyleMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralWrapStyle_setter">Метод:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralWrapStyle_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralShowTabBorderMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralShowTabBorder_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -191,6 +191,15 @@
       <string id="org-mate-marco-general-auto-raise-delay">Задержка при восстановлении</string>
       <string id="org-mate-marco-general-auto-raise-delay_help">Временной интервал в миллисекундах, по истечении которого окно в фокусе будет поднято поверх остальных.</string>
 
+      <string id="org-mate-marco-general-center-new-windows">Новые окна по центру</string>
+      <string id="org-mate-marco-general-center-new-windows_help">Если включено, то новые окна будут открываться по центру экрана.</string>
+
+      <string id="org-mate-marco-general-icon-size">Размер иконок</string>
+      <string id="org-mate-marco-general-icon-size_help">Устанавливает размер иконок в окне переключения приложений Alt+Tab.</string>
+
+      <string id="org-mate-marco-general-alt-tab-max-columns">Размер окна переключения Alt+Tab</string>
+      <string id="org-mate-marco-general-alt-tab-max-columns_help">Устанавливает количество колонок в окне переключения приложений Alt+Tab.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -613,6 +622,31 @@ last - повторить последнее действие</text>
         <presentation id="OrgMateMarcoGeneralAutoRaiseDelayMachine-pr">
         <decimalTextBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter" defaultValue="500">Миллисекунды:</decimalTextBox>
         <checkBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralCenterNewWindowsMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralCenterNewWindows_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralIconSizeUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralIconSize_setter" defaultValue="48">Размер:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralIconSizeMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralIconSize_setter" defaultValue="48">Размер:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralIconSize_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAltTabMaxColumnsUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter" defaultValue="5">Количество колонок:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAltTabMaxColumnsMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter" defaultValue="5">Количество колонок:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -200,6 +200,15 @@
       <string id="org-mate-marco-general-alt-tab-max-columns">Размер окна переключения Alt+Tab</string>
       <string id="org-mate-marco-general-alt-tab-max-columns_help">Устанавливает количество колонок в окне переключения приложений Alt+Tab.</string>
 
+      <string id="org-mate-peripherals-keyboard-delay">Задержка перед повтором</string>
+      <string id="org-mate-peripherals-keyboard-delay_help">Задержка перед повтором нажатой и удерживаемой клавишей.</string>
+
+      <string id="org-mate-peripherals-keyboard-repeat">Включить повтор</string>
+      <string id="org-mate-peripherals-keyboard-repeat_help">Включить повтор нажатой и удерживаемой клавиши.</string>
+
+      <string id="org-mate-peripherals-keyboard-rate">Скорость повтора</string>
+      <string id="org-mate-peripherals-keyboard-rate_help">Устанавливает скорость повтора нажатой и удерживаемой клавиши.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -647,6 +656,31 @@ last - повторить последнее действие</text>
         <presentation id="OrgMateMarcoGeneralAltTabMaxColumnsMachine-pr">
         <decimalTextBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter" defaultValue="5">Количество колонок:</decimalTextBox>
         <checkBox refId="OrgMateMarcoGeneralAltTabMaxColumns_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardDelayUser-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardDelay_setter">Задержка:</decimalTextBox>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardDelayMachine-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardDelay_setter">Задержка:</decimalTextBox>
+        <checkBox refId="OrgMatePeripheralsKeyboardDelay_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardRepeatMachine-pr">
+        <checkBox refId="OrgMatePeripheralsKeyboardRepeat_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardRateUser-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardRate_setter">Скорость повтора:</decimalTextBox>
+      </presentation>
+
+      <presentation id="OrgMatePeripheralsKeyboardRateMachine-pr">
+        <decimalTextBox refId="OrgMatePeripheralsKeyboardRate_setter">Скорость повтора:</decimalTextBox>
+        <checkBox refId="OrgMatePeripheralsKeyboardRate_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -122,6 +122,18 @@
       <string id="org-mate-marco-general-allow-tiling">Изменение размеров при перетаскивании</string>
       <string id="org-mate-marco-general-allow-tiling_help">Включает изменение размеров окна при перетаскивании его в различные области экрана.</string>
 
+      <string id="org-mate-marco-general-num-workspaces">Количество рабочих областей</string>
+      <string id="org-mate-marco-general-num-workspaces_help">Установка количества рабочих областей. Интервал допустимых значений 1-36.</string>
+
+      <string id="org-mate-marco-general-placement-mode">Расположение новых окон</string>
+      <string id="org-mate-marco-general-placement-mode_help">Устанавливает расположение новых окон на экране. automatic - автоматически, в зависимости от занятости экрана другими окнами, pointer - в зависимости от положения курсора мыши на экране, manual -  пользователь сам выбирает положение нокового окна на экране.</string>
+      <string id="org-mate-marco-general-placement-mode-automatic">automatic</string>
+      <string id="org-mate-marco-general-placement-mode-pointer">pointer</string>
+      <string id="org-mate-marco-general-placement-mode-manual">manual</string>
+
+      <string id="org-mate-marco-general-auto-raise">Подъем окна в фокусе</string>
+      <string id="org-mate-marco-general-auto-raise_help">При включении, окно, получившее фокус, отображается поверх остальных автоматически. Настройка "переключение окон" должна быть установлена в "sloppy" или "mouse". Интервал, по истечении которого, окно поднимается, устанавливается в настройке "задержка при восстановлении"</string>
+
     </stringTable>
 
     <presentationTable>
@@ -383,6 +395,31 @@
 
       <presentation id="OrgMateMarcoGeneralAllowTilingMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralAllowTiling_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralNumWorkspacesUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralNumWorkspaces_setter" defaultValue="2">Количество:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralNumWorkspacesMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralNumWorkspaces_setter" defaultValue="2">Количество:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralNumWorkspaces_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralPlacementModeUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralPlacementMode_setter">Расположение:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralPlacementModeMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralPlacementMode_setter">Расположение:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralPlacementMode_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralAutoRaiseMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralAutoRaise_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -185,6 +185,12 @@
       <string id="org-mate-marco-general-titlebar-uses-system-font">Системный шрифт в заголовке окон</string>
       <string id="org-mate-marco-general-titlebar-uses-system-font_help">При включении в заголовках окон будет использоваться системный шрифт.</string>
 
+      <string id="org-mate-marco-general-compositing-fast-alt-tab">Миниатюры при переключении окон</string>
+      <string id="org-mate-marco-general-compositing-fast-alt-tab_help">Если включено, то вместо миниатюр в окне переключения Alt+Tab будут отображаться иконки приложения.</string>
+
+      <string id="org-mate-marco-general-auto-raise-delay">Задержка при восстановлении</string>
+      <string id="org-mate-marco-general-auto-raise-delay_help">Временной интервал в миллисекундах, по истечении которого окно в фокусе будет поднято поверх остальных.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -592,6 +598,21 @@ last - повторить последнее действие</text>
 
       <presentation id="OrgMateMarcoGeneralTitlebarUsesSystemFontMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralTitlebarUsesSystemFont_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralCompositingFastAltTabMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralCompositingFastAltTab_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAutoRaiseDelayUser-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter" defaultValue="500">Миллисекунды:</decimalTextBox>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralAutoRaiseDelayMachine-pr">
+        <decimalTextBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter" defaultValue="500">Миллисекунды:</decimalTextBox>
+        <checkBox refId="OrgMateMarcoGeneralAutoRaiseDelay_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -111,6 +111,17 @@
       <string id="org-mate-marco-general-show-tab-border">Граница окна при переключении</string>
       <string id="org-mate-marco-general-show-tab-border_help">Показывать ли границу окна при переключении с помощью Alt+Tab.</string>
 
+      <string id="org-mate-marco-general-allow-top-tiling">Разворачивание при перетаскивании</string>
+      <string id="org-mate-marco-general-allow-top-tiling_help">Включает разворачивание окна во весь экран при его перетаскивании в верхнюю центральную часть экрана.</string>
+
+      <string id="org-mate-marco-general-focus-new-windows">Переключение фокуса на новое окно</string>
+      <string id="org-mate-marco-general-focus-new-windows_help">Устанавливает способ переключения фокуса на новое окно. smart - новое окно получает фокус при создании. strict - при создании нового окна по команде из терминала, новое окно фокус не получает.</string>
+      <string id="org-mate-Marco-general-focus-new-windows-smart">smart</string>
+      <string id="org-mate-Marco-general-focus-new-windows-strict">strict</string>
+
+      <string id="org-mate-marco-general-allow-tiling">Изменение размеров при перетаскивании</string>
+      <string id="org-mate-marco-general-allow-tiling_help">Включает изменение размеров окна при перетаскивании его в различные области экрана.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -352,6 +363,26 @@
 
       <presentation id="OrgMateMarcoGeneralShowTabBorderMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralShowTabBorder_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralAllowTopTilingMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralAllowTopTilingMachine_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusNewWindowsUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusNewWindows_setter">Передача фокуса:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusNewWindowsMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusNewWindows_setter">Передача фокуса:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralFocusNewWindows_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralAllowTilingMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralAllowTiling_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -170,6 +170,21 @@
       <string id="org-mate-marco-general-action-double-click-titlebar-menu">menu</string>
       <string id="org-mate-marco-general-action-double-click-titlebar-last">last</string>
 
+      <string id="org-mate-marco-general-theme">Тема оформления</string>
+      <string id="org-mate-marco-general-theme_help">Устанавливает тему, отвечающущю за отображение границ окон, заголовка и т.д.</string>
+
+      <string id="org-mate-marco-general-titlebar-font">Шрифт заголовков</string>
+      <string id="org-mate-marco-general-titlebar-font_help">Устанавливает шрифт заголовков окон</string>
+
+      <string id="org-mate-marco-general-focus-mode">Переключение фокуса окон</string>
+      <string id="org-mate-marco-general-focus-mode_help">Установка режима переключения фокуса окон.</string>
+      <string id="org-mate-marco-general-focus-mode-click">click</string>
+      <string id="org-mate-marco-general-focus-mode-sloppy">sloppy</string>
+      <string id="org-mate-marco-general-focus-mode-mouse">mouse</string>
+
+      <string id="org-mate-marco-general-titlebar-uses-system-font">Системный шрифт в заголовке окон</string>
+      <string id="org-mate-marco-general-titlebar-uses-system-font_help">При включении в заголовках окон будет использоваться системный шрифт.</string>
+
     </stringTable>
 
     <presentationTable>
@@ -534,6 +549,49 @@ lower - скрыть окно под другими окнами на экран
 menu - открыть меню окна
 last - повторить последнее действие</text>
         <checkBox refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralThemeUser-pr">
+        <textBox refId="OrgMateMarcoGeneralTheme_setter">
+          <label>Тема:</label>
+        </textBox>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralThemeMachine-pr">
+        <textBox refId="OrgMateMarcoGeneralTheme_setter">
+          <label>Тема:</label>
+        </textBox>
+        <checkBox refId="OrgMateMarcoGeneralTheme_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralTitlebarFont-pr">
+        <textBox refId="OrgMateMarcoGeneralTheme_setter">
+          <label>Тема:</label>
+        </textBox>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralTitlebarFontMachine-pr">
+        <textBox refId="OrgMateMarcoGeneralTitlebarFont_setter">
+          <label>Тема:</label>
+        </textBox>
+        <checkBox refId="OrgMateMarcoGeneralTitlebarFont_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusModeUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusMode_setter">Режим переключения фокуса окон:</dropdownList>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralFocusModeMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralFocusMode_setter">Режим переключения фокуса окон:</dropdownList>
+        <checkBox refId="OrgMateMarcoGeneralFocusMode_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralTitlebarUsesSystemFontMachine-pr">
+        <checkBox refId="OrgMateMarcoGeneralTitlebarUsesSystemFont_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -134,6 +134,42 @@
       <string id="org-mate-marco-general-auto-raise">Подъем окна в фокусе</string>
       <string id="org-mate-marco-general-auto-raise_help">При включении, окно, получившее фокус, отображается поверх остальных автоматически. Настройка "переключение окон" должна быть установлена в "sloppy" или "mouse". Интервал, по истечении которого, окно поднимается, устанавливается в настройке "задержка при восстановлении"</string>
 
+      <string id="org-mate-marco-general-action-middle-click-titlebar">Действие по нажатию средней кнопки</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar_help">Установка действия, выполняемого по нажатию средней кнопки мыши.</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_shade">toggle_shade</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_maximize">toggle_maximize</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_horizontally">toggle_maximize_horizontally</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-toggle_maximize_vertically">toggle_maximize_vertically</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-minimize">minimize</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-none">none</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-lower">lower</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-menu">menu</string>
+      <string id="org-mate-marco-general-action-middle-click-titlebar-last">last</string>
+
+      <string id="org-mate-marco-general-action-right-click-titlebar">Действие по нажатию правой кнопки</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar_help">Установка действия, выполняемого по нажатию правой кнопки мыши.</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_shade">toggle_shade</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_maximize">toggle_maximize</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_maximize_horizontally">toggle_maximize_horizontally</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-toggle_maximize_vertically">toggle_maximize_vertically</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-minimize">minimize</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-none">none</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-lower">lower</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-menu">menu</string>
+      <string id="org-mate-marco-general-action-right-click-titlebar-last">last</string>
+
+      <string id="org-mate-marco-general-action-double-click-titlebar">Действие по двойному щелчку</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar_help">Установка действия, выполняемого по двойному щелчку левой кнопкой по заголовку.</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_shade">toggle_shade</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_maximize">toggle_maximize</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_maximize_horizontally">toggle_maximize_horizontally</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-toggle_maximize_vertically">toggle_maximize_vertically</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-minimize">minimize</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-none">none</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-lower">lower</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-menu">menu</string>
+      <string id="org-mate-marco-general-action-double-click-titlebar-last">last</string>
+
     </stringTable>
 
     <presentationTable>
@@ -420,6 +456,84 @@
 
       <presentation id="OrgMateMarcoGeneralAutoRaiseMachine-pr">
         <checkBox refId="OrgMateMarcoGeneralAutoRaise_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralActionMiddleClickTitlebarUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter">Действие:</dropdownList>
+        <text>toggle_shade - свернуть до заголовка
+toggle_maximize - развернуть во весь экран
+toggle_maximize_horizontally - развернуть во весь экран по горизонтали
+toggle_maximize_vertically - развернуть во весь экран по вертикали
+none - ничего не делать
+lower - скрыть окно под другими окнами на экране
+menu - открыть меню окна
+last - повторить последнее действие</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralActionMiddleClickTitlebarMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter">Действие:</dropdownList>
+<text>toggle_shade - свернуть до заголовка
+toggle_maximize - развернуть во весь экран
+toggle_maximize horizontally - развернуть во весь экран по горизонтали
+toggle_maximize vertically - развернуть во весь экран по вертикали
+none - ничего не делать
+lower - скрыть окно под другими окнами на экране
+menu - открыть меню окна
+last - повторить последнее действие</text>
+        <checkBox refId="OrgMateMarcoGeneralActionMiddleClickTitlebar_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+      <presentation id="OrgMateMarcoGeneralActionRightClickTitlebarUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionRightClickTitlebar_setter">Действие:</dropdownList>
+<text>toggle_shade - свернуть до заголовка
+toggle_maximize - развернуть во весь экран
+toggle_maximize horizontally - развернуть во весь экран по горизонтали
+toggle_maximize vertically - развернуть во весь экран по вертикали
+none - ничего не делать
+lower - скрыть окно под другими окнами на экране
+menu - открыть меню окна
+last - повторить последнее действие</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralActionRightClickTitlebarMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionRightClickTitlebar_setter">Действие:</dropdownList>
+<text>toggle_shade - свернуть до заголовка
+toggle_maximize - развернуть во весь экран
+toggle_maximize horizontally - развернуть во весь экран по горизонтали
+toggle_maximize vertically - развернуть во весь экран по вертикали
+none - ничего не делать
+lower - скрыть окно под другими окнами на экране
+menu - открыть меню окна
+last - повторить последнее действие</text>
+        <checkBox refId="OrgMateMarcoGeneralActionRightClickTitlebar_setter_blocker">блокировать</checkBox>
+        <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralActionDoubleClickTitlebarUser-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter">Действие:</dropdownList>
+<text>toggle_shade - свернуть до заголовка
+toggle_maximize - развернуть во весь экран
+toggle_maximize horizontally - развернуть во весь экран по горизонтали
+toggle_maximize vertically - развернуть во весь экран по вертикали
+none - ничего не делать
+lower - скрыть окно под другими окнами на экране
+menu - открыть меню окна
+last - повторить последнее действие</text>
+      </presentation>
+
+        <presentation id="OrgMateMarcoGeneralActionDoubleClickTitlebarMachine-pr">
+        <dropdownList noSort="true" defaultItem="0" refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter">Действие:</dropdownList>
+<text>toggle_shade - свернуть до заголовка
+toggle_maximize - развернуть во весь экран
+toggle_maximize horizontally - развернуть во весь экран по горизонтали
+toggle_maximize vertically - развернуть во весь экран по вертикали
+none - ничего не делать
+lower - скрыть окно под другими окнами на экране
+menu - открыть меню окна
+last - повторить последнее действие</text>
+        <checkBox refId="OrgMateMarcoGeneralActionDoubleClickTitlebar_setter_blocker">блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 


### PR DESCRIPTION
Настройки оконного менеджера Marco. Документация по [ссылке](https://intranet.altlinux.ru/%D0%93%D1%80%D1%83%D0%BF%D0%BF%D0%BE%D0%B2%D1%8B%D0%B5_%D0%9F%D0%BE%D0%BB%D0%B8%D1%82%D0%B8%D0%BA%D0%B8/%D0%A3%D0%BF%D1%80%D0%B0%D0%B2%D0%BB%D0%B5%D0%BD%D0%B8%D0%B5_gsettings#.D0.9D.D0.B0.D1.81.D1.82.D1.80.D0.BE.D0.B9.D0.BA.D0.B8_.D0.BE.D0.BA.D0.BE.D0.BD.D0.BD.D0.BE.D0.B3.D0.BE_.D0.BC.D0.B5.D0.BD.D0.B5.D0.B4.D0.B6.D0.B5.D1.80.D0.B0_Marco_.28.D0.B2_.D1.80.D0.B0.D0.B7.D1.80.D0.B0.D0.B1.D0.BE.D1.82.D0.BA.D0.B5.29) 