### PR TITLE
Fix gsettings

### DIFF
--- a/en-US/basealtgsettings.adml
+++ b/en-US/basealtgsettings.adml
@@ -10,19 +10,19 @@
 
       <string id="org-mate-background-picture-options">Desktop background options</string>
       <string id="org-mate-background-picture-options_help">Set how to display the desktop background. Possible values: "none", "wallpaper", "centered", "scaled", "stretched", "zoom", "spanned".</string>
-      <string id="org-mate-background-picture-options_None">none</string>
-      <string id="org-mate-background-picture-options_Wallpaper">wallpaper</string>
-      <string id="org-mate-background-picture-options_Centered">centered</string>
-      <string id="org-mate-background-picture-options_Scaled">scaled</string>
-      <string id="org-mate-background-picture-options_Stretched">stretched</string>
-      <string id="org-mate-background-picture-options_Zoom">zoom</string>
-      <string id="org-mate-background-picture-options_Spanned">spanned</string>
+      <string id="org-mate-background-picture-options_None">None</string>
+      <string id="org-mate-background-picture-options_Wallpaper">Wallpaper</string>
+      <string id="org-mate-background-picture-options_Centered">Centered</string>
+      <string id="org-mate-background-picture-options_Scaled">Scaled</string>
+      <string id="org-mate-background-picture-options_Stretched">Stretched</string>
+      <string id="org-mate-background-picture-options_Zoom">Zoom</string>
+      <string id="org-mate-background-picture-options_Spanned">Spanned</string>
 
       <string id="org-mate-background-color-shading-type">Gradient type</string>
       <string id="org-mate-background-color-shading-type_help">Set the gradient type: vertical, horizontal, or solid fill.</string>
-      <string id="org-mate-background-color-shading-type-horizontal-gradient">horizontal gradient</string>
-      <string id="org-mate-background-color-shading-type-vertical-gradient">vertical gradient</string>
-      <string id="org-mate-background-color-shading-type-solid">solid fill</string>
+      <string id="org-mate-background-color-shading-type-horizontal-gradient">Horizontal gradient</string>
+      <string id="org-mate-background-color-shading-type-vertical-gradient">Vertical gradient</string>
+      <string id="org-mate-background-color-shading-type-solid">Solid fill</string>
 
       <string id="org-mate-background-picture-filename">Desktop background image</string>
       <string id="org-mate-background-picture-filename_help">Set the image to use as the desktop background.</string>
@@ -38,10 +38,10 @@
 
       <string id="org-mate-screensaver-mode">Screen saver mode</string>
       <string id="org-mate-screensaver-mode_help">Set screen saver mode. Possible options: "disabled" — disabled, "blank-only" — an empty screen,"single" — use one theme specified by the "themes" key,"random" — use a randomly selected theme.</string>
-      <string id="org-mate-screensaver-mode_disabled">disabled</string>
-      <string id="org-mate-screensaver-mode_blank_only">blank screen</string>
-      <string id="org-mate-screensaver-mode_random">random</string>
-      <string id="org-mate-screensaver-mode_single">single</string>
+      <string id="org-mate-screensaver-mode_disabled">Disabled</string>
+      <string id="org-mate-screensaver-mode_blank_only">Blank screen</string>
+      <string id="org-mate-screensaver-mode_random">Random</string>
+      <string id="org-mate-screensaver-mode_single">Single</string>
 
       <string id="org-mate-screensaver-lock-delay">Lock delay</string>
       <string id="org-mate-screensaver-lock-delay_help">Set the delay in minutes between screen saver activation and computer lock.</string>
@@ -78,9 +78,9 @@
 
       <string id="org-gnome-vino-icon-visibility">Connection icon</string>
       <string id="org-gnome-vino-icon-visibility_help">This key controls the behavior of the connection status icon. There are three options: "always" - the icon will always be present; "client" - the icon will only be present when someone is connected (this is the default behavior); "never" - the icon will not be present.</string>
-      <string id="org-gnome-vino-icon-visibility-never">never</string>
-      <string id="org-gnome-vino-icon-visibility-always">always</string>
-      <string id="org-gnome-vino-icon-visibility-client">client</string>
+      <string id="org-gnome-vino-icon-visibility-never">Never</string>
+      <string id="org-gnome-vino-icon-visibility-always">Always</string>
+      <string id="org-gnome-vino-icon-visibility-client">Client</string>
 
       <string id="org-gnome-vino-enabled">Remote access</string>
       <string id="org-gnome-vino-enabled_help">If true, allows remote access to desktop via the RFB protocol. Users on remote machines may then connect to the desktop using a VNC player.</string>
@@ -93,8 +93,8 @@
 
       <string id="org-gnome-vino-authentication-methods">Authentication methods</string>
       <string id="org-gnome-vino-authentication-methods_help">Lists the authentication methods with which remote users may access the desktop.  There are two possible authentication methods; "vnc" causes the remote user to be prompted for a password (the password is specified by the vnc-password key) before connecting and "none" which allows any remote user to connect.</string>
-      <string id="org-gnome-vino-authentication-methods-none">none</string>
-      <string id="org-gnome-vino-authentication-methods-vnc">vnc</string>
+      <string id="org-gnome-vino-authentication-methods-none">None</string>
+      <string id="org-gnome-vino-authentication-methods-vnc">Vnc</string>
 
       <string id="org-gnome-vino-vnc-password">Password for remote access</string>
       <string id="org-gnome-vino-vnc-password_help">The password which the remote user will be prompted for if the "vnc" authentication method is used. The password specified by the key is base64 encoded.  The special value of 'keyring' (which is not valid base64) means that the password is stored in the GNOME keyring.</string>
@@ -106,7 +106,7 @@
         <textBox refId="OrgMateBackgroundSecondaryColor_setter">
           <label>Set the color:</label>
         </textBox>
-        <checkBox refId="OrgMateBackgroundSecondaryColor_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateBackgroundSecondaryColor_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -122,7 +122,7 @@
 
       <presentation id="OrgMateBackgroundPictureOptionsMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgMateBackgroundPictureOptions_setter">Method for displaying the desktop background:</dropdownList>
-        <checkBox refId="OrgMateBackgroundPictureOptions_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateBackgroundPictureOptions_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -132,21 +132,21 @@
 
       <presentation id="OrgMateBackgroundColorShadingTypeMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgMateBackgroundColorShadingType_setter">Set the gradient type:</dropdownList>
-        <checkBox refId="OrgMateBackgroundColorShadingType_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateBackgroundColorShadingType_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateBackgroundPictureFilenameUser-pr">
         <textBox refId="OrgMateBackgroundPictureFilename_setter">
-          <label>file:</label>
+          <label>File:</label>
         </textBox>
       </presentation>
 
       <presentation id="OrgMateBackgroundPictureFilenameMachine-pr">
         <textBox refId="OrgMateBackgroundPictureFilename_setter">
-          <label>file:</label>
+          <label>File:</label>
         </textBox>
-        <checkBox refId="OrgMateBackgroundPictureFilename_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateBackgroundPictureFilename_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -160,17 +160,17 @@
         <textBox refId="OrgMateBackgroundPrimaryColor_setter">
           <label>Set the color:</label>
         </textBox>
-        <checkBox refId="OrgMateBackgroundPrimaryColor_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateBackgroundPrimaryColor_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateScreesaverIdleActivationEnabledMachine-pr">
-        <checkBox refId="OrgMateScreesaverIdleActivationEnabled_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreesaverIdleActivationEnabled_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateScreensaverLockEnabledMachine-pr">
-        <checkBox refId="OrgMateScreensaverLockEnabled_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverLockEnabled_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -180,7 +180,7 @@
 
       <presentation id="OrgMateScreensaverModeMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgMateScreensaverMode_setter">Select an operating mode:</dropdownList>
-        <checkBox refId="OrgMateScreensaverMode_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverMode_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -192,7 +192,7 @@
       <presentation id="OrgMateScreensaverLockDelayMachine-pr">
         <text>The interval in minutes between the activation of the screen saver and the appearance of the logout dialog during activation</text>
         <decimalTextBox refId="OrgMateScreensaverLockDelay_setter" defaultValue="2">Time in minutes:</decimalTextBox>
-        <checkBox refId="OrgMateScreensaverLockDelay_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverLockDelay_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -204,7 +204,7 @@
       <presentation id="OrgMateScreensaverLogoutDelayMachine-pr">
         <text>The number of minutes after which, after activating the screen saver, the screen will be locked</text>
         <decimalTextBox refId="OrgMateScreensaverLogoutDelay_setter" defaultValue="3">Time in minutes:</decimalTextBox>
-        <checkBox refId="OrgMateScreensaverLogoutDelay_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverLogoutDelay_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -216,47 +216,47 @@
       <presentation id="OrgMateScreensaverCycleDelayMachine-pr">
         <text>The interval in minutes between changing the themes of the screen saver</text>
         <decimalTextBox refId="OrgMateScreensaverCycleDelay_setter" defaultValue="2">Time in minutes:</decimalTextBox>
-        <checkBox refId="OrgMateScreensaverCycleDelay_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverCycleDelay_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateScreensaverLogoutEnabledMachine-pr">
-        <checkBox refId="OrgMateScreensaverLogoutEnabled_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverLogoutEnabled_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateScreensaverUserSwitchEnabledMachine-pr">
-        <checkBox refId="OrgMateScreensaverUserSwitchEnabled_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateScreensaverUserSwitchEnabled_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableLogOutMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableLogOut_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateLockdownDisableLogOut_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableLockScreenMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableLockScreen_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateLockdownDisableLockScreen_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableUserSwitchingMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableUserSwitching_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateLockdownDisableUserSwitching_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableThemeSettingsMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableThemeSettings_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgMateLockdownDisableThemeSettings_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoViewOnlyMachine-pr">
-        <checkBox refId="OrgGnomeVinoViewOnly_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoViewOnly_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoPromptEnabledMachine-pr">
-        <checkBox refId="OrgGnomeVinoPromptEnabled_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoPromptEnabled_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -266,12 +266,12 @@
 
       <presentation id="OrgGnomeVinoIconVisibilityMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgGnomeVinoIconVisibility_setter">Show notification:</dropdownList>
-        <checkBox refId="OrgGnomeVinoIconVisibility_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoIconVisibility_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoEnabledMachine-pr">
-        <checkBox refId="OrgGnomeVinoEnabled_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoEnabled_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -281,12 +281,12 @@
 
       <presentation id="OrgGnomeVinoAlternativePortMachine-pr">
         <decimalTextBox refId="OrgGnomeVinoAlternativePort_setter" defaultValue="5000">Port:</decimalTextBox>
-        <checkBox refId="OrgGnomeVinoAlternativePort_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoAlternativePort_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoUseAlternativePortMachine-pr">
-        <checkBox refId="OrgGnomeVinoUseAlternativePort_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoUseAlternativePort_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -296,7 +296,7 @@
 
       <presentation id="OrgGnomeVinoAuthenticationMethodsMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgGnomeVinoAuthenticationMethods_setter">Method:</dropdownList>
-        <checkBox refId="OrgGnomeVinoAuthenticationMethods_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoAuthenticationMethods_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 
@@ -310,7 +310,7 @@
         <textBox refId="OrgGnomeVinoVncPassword_setter">
           <label>Password:</label>
         </textBox>
-        <checkBox refId="OrgGnomeVinoVncPassword_setter_blocker">lock</checkBox>
+        <checkBox refId="OrgGnomeVinoVncPassword_setter_blocker">Lock</checkBox>
         <text>Lock changes to this setting. User policies for this setting will be ignored.</text>
       </presentation>
 

--- a/ru-RU/basealtgsettings.adml
+++ b/ru-RU/basealtgsettings.adml
@@ -6,98 +6,164 @@
   <resources>
     <stringTable>
       <string id="org-mate-background-secondary-color">Конечный цвет градиента</string>
-      <string id="org-mate-background-secondary-color_help">Установите правый или нижний цвет при отрисовке градиента. Не используется при сплошном цвете.</string>
+      <string id="org-mate-background-secondary-color_help">Устанавливает цвет правого или нижнего края рабочего стола при отрисовке градиента. Не используется, если в параметре «Тип градиента» выбрано значение «Сплошная заливка».</string>
 
       <string id="org-mate-background-picture-options">Метод отображения картинки фона</string>
-      <string id="org-mate-background-picture-options_help">Устанавливает метод отображения картинки фона рабочего  стола. Возможные значения: «none», «wallpaper», «centered», «scaled», «stretched», «zoom», «spanned».</string>
-      <string id="org-mate-background-picture-options_None">none</string>
-      <string id="org-mate-background-picture-options_Wallpaper">wallpaper</string>
-      <string id="org-mate-background-picture-options_Centered">centered</string>
-      <string id="org-mate-background-picture-options_Scaled">scaled</string>
-      <string id="org-mate-background-picture-options_Stretched">stretched</string>
-      <string id="org-mate-background-picture-options_Zoom">zoom</string>
-      <string id="org-mate-background-picture-options_Spanned">spanned</string>
+      <string id="org-mate-background-picture-options_help">Устанавливает метод отображения изображения, заданного параметром «Картинка фона рабочего стола».
+
+Возможные значения:
+
+«None» (нет);
+
+«Wallpaper» (мозаика) — дублирует изображение в оригинальном размере таким образом, что изображение полностью покрывает рабочий стол;
+
+«Centered» (по центру) — отображает изображение в центре рабочего стола в соответствии с оригинальным размером изображения;
+
+«Scaled» (масштаб) — увеличивает изображение, сохраняя пропорции, до тех пор, пока величина одной из границ изображения не совпадет с величиной одной из границ экрана;
+
+«Stretched» (растянуть) — увеличивает изображение для соответствия размеру рабочего стола, изменяя пропорции при необходимости;
+
+«Zoom» (масштаб) — увеличивает наименьшую из сторон изображения до тех пор, пока её величина не совпадёт с величиной соответствующей границы экрана; изображение может быть обрезано по другой стороне;
+
+«Spanned» (заполнение) — увеличивает изображение, сохраняя пропорции, до тех пор, пока величина одной из границ изображения не совпадет с величиной одной из границ экрана.</string>
+      <string id="org-mate-background-picture-options_None">None</string>
+      <string id="org-mate-background-picture-options_Wallpaper">Wallpaper</string>
+      <string id="org-mate-background-picture-options_Centered">Centered</string>
+      <string id="org-mate-background-picture-options_Scaled">Scaled</string>
+      <string id="org-mate-background-picture-options_Stretched">Stretched</string>
+      <string id="org-mate-background-picture-options_Zoom">Zoom</string>
+      <string id="org-mate-background-picture-options_Spanned">Spanned</string>
 
       <string id="org-mate-background-color-shading-type">Тип градиента</string>
-      <string id="org-mate-background-color-shading-type_help">Установите тип градиента: вертикальный, горизонтальный или сплошная заливка.</string>
-      <string id="org-mate-background-color-shading-type-horizontal-gradient">горизонтальный градиент</string>
-      <string id="org-mate-background-color-shading-type-vertical-gradient">вертикальный градиент</string>
-      <string id="org-mate-background-color-shading-type-solid">сплошная заливка</string>
+      <string id="org-mate-background-color-shading-type_help">Устанавливает тип градиента:
+
+«Горизонтальный градиент» — градиентный эффект от левого края экрана к правому;
+
+«Вертикальный градиент» — градиентный эффект от верхнего края экрана к нижнему;
+
+«Сплошная заливка» — заполнить фон рабочего стола одним цветом.
+
+Этот параметр имеет смысл, только если не установлен параметр «Картинка фона рабочего стола».</string>
+      <string id="org-mate-background-color-shading-type-horizontal-gradient">Горизонтальный градиент</string>
+      <string id="org-mate-background-color-shading-type-vertical-gradient">Вертикальный градиент</string>
+      <string id="org-mate-background-color-shading-type-solid">Сплошная заливка</string>
 
       <string id="org-mate-background-picture-filename">Картинка фона рабочего стола</string>
-      <string id="org-mate-background-picture-filename_help">Укажите файл c картинкой для установки в качестве фона рабочего стола.</string>
+      <string id="org-mate-background-picture-filename_help">Позволяет установить изображение в качестве фона рабочего стола, указав файл (например, /usr/share/backgrounds/mate/nature/Wood.jpg), содержащий изображение.</string>
 
       <string id="org-mate-background-primary-color">Начальный цвет градиента (цвет сплошной заливки)</string>
-      <string id="org-mate-background-primary-color_help">Установите левый или верхний, или сплошной цвет при отрисовке градиента, в зависимости от установленного типа градиента.</string>
+      <string id="org-mate-background-primary-color_help">Устанавливает цвет левого или верхнего края рабочего стола, или цвет сплошной заливки при отрисовке градиента, в зависимости от установленного типа градиента.</string>
 
       <string id="org-mate-screensaver-idle-activation-enabled">Включение хранителя экрана</string>
-      <string id="org-mate-screensaver-idle-activation-enabled_help">Установите для включения хранителя экрана при бездействии компьютера</string>
+      <string id="org-mate-screensaver-idle-activation-enabled_help">Установка этого параметра включает хранитель экрана при бездействии компьютера.</string>
 
       <string id="org-mate-screensaver-lock-enabled">Блокировка компьютера</string>
-      <string id="org-mate-screensaver-lock-enabled_help">Включите, чтобы заблокировать компьютер при активации хранителя экрана. Блокировка будет включена через интервал времени, установленный настройкой "Время до блокировки паролем"</string>
+      <string id="org-mate-screensaver-lock-enabled_help">Включает блокировку компьютера при активации хранителя экрана. Блокировка будет включена через интервал времени, установленный в параметре «Время до блокировки паролем».
+
+Этот параметр имеет смысл только при активированном параметре «Включение хранителя экрана».</string>
 
       <string id="org-mate-screensaver-mode">Режим работы</string>
-      <string id="org-mate-screensaver-mode_help">Режим работы хранителя экрана. Возможные варианты: «disabled» — отключён, «blank-only» — пустой экран, «single» — использовать одну тему, указанную ключом «темы», «random» — использовать случайно выбранную тему.</string>
-      <string id="org-mate-screensaver-mode_disabled">отключён</string>
-      <string id="org-mate-screensaver-mode_blank_only">пустой экран</string>
-      <string id="org-mate-screensaver-mode_random">случайные темы</string>
-      <string id="org-mate-screensaver-mode_single">выбранная тема</string>
+      <string id="org-mate-screensaver-mode_help">Устанавливает режим работы хранителя экрана. Этот параметр имеет смысл только при активированном параметре «Включение хранителя экрана».
+
+Возможные значения:
+
+«Отключён» — отключён;
+
+«Пустой экран» — не показывать никаких изображений, только чёрный экран;
+
+«Случайные темы» — выбрать тему хранителя экрана случайным образом;
+
+«Выбранная тема» — показывать одну (указанную) тему хранителя экрана.</string>
+      <string id="org-mate-screensaver-mode_disabled">Отключён</string>
+      <string id="org-mate-screensaver-mode_blank_only">Пустой экран</string>
+      <string id="org-mate-screensaver-mode_random">Случайные темы</string>
+      <string id="org-mate-screensaver-mode_single">Выбранная тема</string>
 
       <string id="org-mate-screensaver-lock-delay">Время до блокировки паролем</string>
-      <string id="org-mate-screensaver-lock-delay_help">Установите количество минут по истечении которых, после активации хранителя экрана, компьютер будет заблокирован</string>
+      <string id="org-mate-screensaver-lock-delay_help">Устанавливает количество минут, по истечении которых после активации хранителя экрана, компьютер будет заблокирован.
+
+Этот параметр имеет смысл только при активированных параметрах «Включение хранителя экрана» и «Блокировка компьютера».</string>
 
       <string id="org-mate-screensaver-logout-delay">Время до выхода из сеанса</string>
-      <string id="org-mate-screensaver-logout-delay_help">Установите количество минут, через которое после активации хранителя экрана будет появляться диалог выхода из сеанса. Этот параметр активен, если установлено значение TRUE для параметра logout-enable</string>
+      <string id="org-mate-screensaver-logout-delay_help">Устанавливает количество минут, по истечении которых после активации хранителя экрана, пользователю будет предоставлена возможность выхода из сеанса.
+
+Этот параметр имеет смысл только при активированных параметрах «Включение хранителя экрана» и «Выход из системы после блокировки».</string>
 
       <string id="org-mate-screensaver-cycle-delay">Время смены тем</string>
-      <string id="org-mate-screensaver-cycle-delay_help">Установите интервал в минутах между сменами тем хранителя экрана.</string>
+      <string id="org-mate-screensaver-cycle-delay_help">Устанавливает интервал (в минутах) между сменами тем хранителя экрана.
+
+Этот параметр имеет смысл только при активированном параметре «Включение хранителя экрана» и если для параметра «Режим работы» установлено значение «Случайные темы».</string>
 
       <string id="org-mate-screensaver-user-switch-enabled">Переключить пользователя после блокировки</string>
-      <string id="org-mate-screensaver-user-switch-enabled_help">Включите, чтобы диалог разблокирования экрана предоставлял возможность переключиться на другую учётную запись.</string>
+      <string id="org-mate-screensaver-user-switch-enabled_help">Добавляет кнопку «Переключить пользователя» к диалогу разблокирования экрана.
+
+Этот параметр имеет смысл только при активированном параметре «Включение хранителя экрана» и «Блокировка компьютера».</string>
 
       <string id="org-mate-screensaver-logout-enabled">Выход из системы после блокировки</string>
-      <string id="org-mate-screensaver-logout-enabled_help">Включите, чтобы к диалогу разблокирования экрана  добавилась возможность выхода из системы после некоторой задержки. Время задержки указывается в настройке «Время выхода из сеанса».</string>
+      <string id="org-mate-screensaver-logout-enabled_help">После некоторой задержки добавляет кнопку выхода из системы («Завершить сеанс») к диалогу разблокирования экрана. Время задержки указывается в параметре «Время выхода из сеанса».
+
+Этот параметр имеет смысл только при активированных параметрах «Включение хранителя экрана» и «Блокировка компьютера».</string>
 
       <string id="org-mate-lockdown-disable-log-out">Запрет пользователю завершать сеанс</string>
-      <string id="org-mate-lockdown-disable-log-out_help">Установите, если хотите запретить пользователю завершать сеанс.</string>
+      <string id="org-mate-lockdown-disable-log-out_help">Установка этого параметра запрещает пользователю завершать свой сеанс.</string>
 
       <string id="org-mate-lockdown-disable-lock-screen">Запрет блокировки экрана</string>
-      <string id="org-mate-lockdown-disable-lock-screen_help">Установите, если хотите запретить пользователю блокировать экран.</string>
+      <string id="org-mate-lockdown-disable-lock-screen_help">Установка этого параметра запрещает пользователю блокировать экран паролем.
 
-      <string id="org-mate-lockdown-disable-user-switching">Запретить переключать пользователя</string>
-      <string id="org-mate-lockdown-disable-user-switching_help">Установите, если хотите запретить пользователю переключение на другую учётную запись, пока активен его сеанс.</string>
+При установке данного параметра, значение параметра «Блокировка компьютера» игнорируется.</string>
+
+      <string id="org-mate-lockdown-disable-user-switching">Запрет переключения пользователей</string>
+      <string id="org-mate-lockdown-disable-user-switching_help">Установка этого параметра запрещает пользователю переключение на другую учётную запись, пока активен его сеанс.</string>
 
       <string id="org-mate-lockdown-disable-theme-settings">Запрет выбора тем рабочего стола</string>
-      <string id="org-mate-lockdown-disable-theme-settings_help">Установите, если хотите запретить пользователю изменять настройки темы.</string>
+      <string id="org-mate-lockdown-disable-theme-settings_help">Установка этого параметра запрещает пользователю изменять настройки темы.</string>
 
       <string id="org-gnome-vino-view-only">Удаленное управление</string>
-      <string id="org-gnome-vino-view-only_help">Если установлено, то удаленным пользователям, разрешается только просматривать рабочий стол. Удаленные пользователи не смогут управлять мышью и клавиатурой.</string>
+      <string id="org-gnome-vino-view-only_help">Установка этого параметра запрещает удалённое управление рабочим столом. Удалённым пользователям, разрешается только просматривать рабочий стол, но не управлять мышью и клавиатурой.</string>
 
       <string id="org-gnome-vino-prompt-enabled">Подтверждение при подключении</string>
-      <string id="org-gnome-vino-prompt-enabled_help">Если установлено TRUE, то подключение удаленного пользователя к рабочему столу невозможно без подтверждения локального пользователя. Рекомендуется при отсутствии защиты подключения паролем.</string>
+      <string id="org-gnome-vino-prompt-enabled_help">Включает запрос подтверждения при любой попытке доступа к рабочему столу. Рекомендуется при отсутствии защиты подключения паролем.</string>
 
       <string id="org-gnome-vino-icon-visibility">Иконка подключения </string>
-      <string id="org-gnome-vino-icon-visibility_help">Поведение иконки уведомления о состоянии удаленного подключения</string>
-      <string id="org-gnome-vino-icon-visibility-never">никогда</string>
-      <string id="org-gnome-vino-icon-visibility-always">всегда</string>
-      <string id="org-gnome-vino-icon-visibility-client">только при подключении клиента</string>
+      <string id="org-gnome-vino-icon-visibility_help">Управляет отображением значка подключения в области уведомления.
+
+Возможные значения:
+
+«Никогда» — значок не отображается;
+
+«Всегда» — значок отображается всегда;
+
+«Только при подключении клиента» — значок отображается при подключении удалённого пользователя.</string>
+      <string id="org-gnome-vino-icon-visibility-never">Никогда</string>
+      <string id="org-gnome-vino-icon-visibility-always">Всегда</string>
+      <string id="org-gnome-vino-icon-visibility-client">Только при подключении клиента</string>
 
       <string id="org-gnome-vino-enabled">Удаленный доступ</string>
-      <string id="org-gnome-vino-enabled_help">Если установлено TRUE, то удаленный пользователь может подключаться к локальному рабочему столу с использованием протокола RFB и VNC.</string>
+      <string id="org-gnome-vino-enabled_help">Установка этого параметра разрешает удаленный доступ к рабочему столу с использованием протокола RFB и VNC.</string>
 
       <string id="org-gnome-vino-alternative-port">Альтернативный порт</string>
-      <string id="org-gnome-vino-alternative-port_help">Альтернативный порт подключения. Диапазон значений от 5 000 до 50 000.</string>
+      <string id="org-gnome-vino-alternative-port_help">Альтернативный порт подключения. Диапазон значений от 5 000 до 50 000. По умолчанию используется порт 5 900.
+
+Используется только при установленном параметре «Включить альтернативный порт» </string>
 
       <string id="org-gnome-vino-use-alternative-port">Включить альтернативный порт</string>
-      <string id="org-gnome-vino-use-alternative-port_help">Если установлено, то Vino использует альтернативный порт для подключения(вместо порта по умолчанию 5900), указанные в ключе "alternative-port".</string>
+      <string id="org-gnome-vino-use-alternative-port_help">Включить прослушивание альтернативного порта для удалённых подключений (вместо порта по умолчанию 5 900). Порт указывается в параметре «Альтернативный порт».</string>
 
       <string id="org-gnome-vino-authentication-methods">Методы аутентификации</string>
-      <string id="org-gnome-vino-authentication-methods_help">Методы аутентификации пользователей, подключающихся к удаленному рабочему столу. Есть два метода аутентификации: "vnc" - для подключения необходим пароль и "none" - пароль не требуется.</string>
-      <string id="org-gnome-vino-authentication-methods-none">none</string>
-      <string id="org-gnome-vino-authentication-methods-vnc">vnc</string>
+      <string id="org-gnome-vino-authentication-methods_help">В этом параметре устанавливается метод аутентификации пользователей, подключающихся к удаленному рабочему столу.
+
+Возможные значения:
+
+«Vnc» — для подключения необходим пароль;
+
+«None» — для подключения пароль не требуется.</string>
+      <string id="org-gnome-vino-authentication-methods-none">None</string>
+      <string id="org-gnome-vino-authentication-methods-vnc">Vnc</string>
 
       <string id="org-gnome-vino-vnc-password">Пароль для подключения</string>
-      <string id="org-gnome-vino-vnc-password_help">Пароль, который удаленному пользователю будет предложено ввести, если используется метод аутентификации "vnc". Пароль, указанный ключом, закодирован в кодировке base64.</string>
+      <string id="org-gnome-vino-vnc-password_help">Установка пароля для подключения к рабочему столу. Пароль должен быть закодирован в base64 (для генерации пароля в base64 можно воспользоваться командой: echo -n "password" | base64).
+
+Пароль будет запрашивается только при использовании метода аутентификации «vnc», установленном в параметре «Методы аутентификации».</string>
 
     </stringTable>
 
@@ -106,7 +172,7 @@
         <textBox refId="OrgMateBackgroundSecondaryColor_setter">
           <label>Установите цвет:</label>
         </textBox>
-        <checkBox refId="OrgMateBackgroundSecondaryColor_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateBackgroundSecondaryColor_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -122,7 +188,7 @@
 
       <presentation id="OrgMateBackgroundPictureOptionsMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgMateBackgroundPictureOptions_setter">Метод отображения картинки фона рабочего стола:</dropdownList>
-        <checkBox refId="OrgMateBackgroundPictureOptions_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateBackgroundPictureOptions_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -132,21 +198,21 @@
 
       <presentation id="OrgMateBackgroundColorShadingTypeMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgMateBackgroundColorShadingType_setter">Установите тип градиента:</dropdownList>
-        <checkBox refId="OrgMateBackgroundColorShadingType_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateBackgroundColorShadingType_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateBackgroundPictureFilenameUser-pr">
         <textBox refId="OrgMateBackgroundPictureFilename_setter">
-          <label>файл:</label>
+          <label>Файл:</label>
         </textBox>
       </presentation>
 
       <presentation id="OrgMateBackgroundPictureFilenameMachine-pr">
         <textBox refId="OrgMateBackgroundPictureFilename_setter">
-          <label>файл:</label>
+          <label>Файл:</label>
         </textBox>
-        <checkBox refId="OrgMateBackgroundPictureFilename_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateBackgroundPictureFilename_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -160,17 +226,17 @@
         <textBox refId="OrgMateBackgroundPrimaryColor_setter">
           <label>Установите цвет:</label>
         </textBox>
-        <checkBox refId="OrgMateBackgroundPrimaryColor_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateBackgroundPrimaryColor_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateScreesaverIdleActivationEnabledMachine-pr">
-        <checkBox refId="OrgMateScreesaverIdleActivationEnabled_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreesaverIdleActivationEnabled_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateScreensaverLockEnabledMachine-pr">
-        <checkBox refId="OrgMateScreensaverLockEnabled_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverLockEnabled_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -180,7 +246,7 @@
 
       <presentation id="OrgMateScreensaverModeMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgMateScreensaverMode_setter">Выберите режим работы хранителя экрана:</dropdownList>
-        <checkBox refId="OrgMateScreensaverMode_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverMode_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -192,7 +258,7 @@
       <presentation id="OrgMateScreensaverLockDelayMachine-pr">
         <text>Интервал в минутах между активацией хранителя экрана и появлением диалога выхода из системы при активации</text>
         <decimalTextBox refId="OrgMateScreensaverLockDelay_setter" defaultValue="2">Время в минутах</decimalTextBox>
-        <checkBox refId="OrgMateScreensaverLockDelay_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverLockDelay_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -204,7 +270,7 @@
       <presentation id="OrgMateScreensaverLogoutDelayMachine-pr">
         <text>Количество минут, по истечении которого после активации хранителя экрана, экран будет заблокирован</text>
         <decimalTextBox refId="OrgMateScreensaverLogoutDelay_setter" defaultValue="3">Время в минутах:</decimalTextBox>
-        <checkBox refId="OrgMateScreensaverLogoutDelay_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverLogoutDelay_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -216,47 +282,47 @@
       <presentation id="OrgMateScreensaverCycleDelayMachine-pr">
         <text>Интервал в минутах между сменами тем хранителя экрана</text>
         <decimalTextBox refId="OrgMateScreensaverCycleDelay_setter" defaultValue="2">Время в минутах:</decimalTextBox>
-        <checkBox refId="OrgMateScreensaverCycleDelay_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverCycleDelay_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateScreensaverUserSwitchEnabledMachine-pr">
-        <checkBox refId="OrgMateScreensaverUserSwitchEnabled_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverUserSwitchEnabled_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateScreensaverLogoutEnabledMachine-pr">
-        <checkBox refId="OrgMateScreensaverLogoutEnabled_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateScreensaverLogoutEnabled_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableLogOutMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableLogOut_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateLockdownDisableLogOut_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableLockScreenMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableLockScreen_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateLockdownDisableLockScreen_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableUserSwitchingMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableUserSwitching_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateLockdownDisableUserSwitching_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgMateLockdownDisableThemeSettingsMachine-pr">
-        <checkBox refId="OrgMateLockdownDisableThemeSettings_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgMateLockdownDisableThemeSettings_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoViewOnlyMachine-pr">
-        <checkBox refId="OrgGnomeVinoViewOnly_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoViewOnly_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoPromptEnabledMachine-pr">
-        <checkBox refId="OrgGnomeVinoPromptEnabled_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoPromptEnabled_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -266,12 +332,12 @@
 
       <presentation id="OrgGnomeVinoIconVisibilityMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgGnomeVinoIconVisibility_setter">Показывать уведомление:</dropdownList>
-        <checkBox refId="OrgGnomeVinoIconVisibility_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoIconVisibility_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoEnabledMachine-pr">
-        <checkBox refId="OrgGnomeVinoEnabled_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoEnabled_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -281,12 +347,12 @@
 
         <presentation id="OrgGnomeVinoAlternativePortMachine-pr">
         <decimalTextBox refId="OrgGnomeVinoAlternativePort_setter" defaultValue="5000">Порт:</decimalTextBox>
-        <checkBox refId="OrgGnomeVinoAlternativePort_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoAlternativePort_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
       <presentation id="OrgGnomeVinoUseAlternativePortMachine-pr">
-        <checkBox refId="OrgGnomeVinoUseAlternativePort_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoUseAlternativePort_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -296,7 +362,7 @@
 
       <presentation id="OrgGnomeVinoAuthenticationMethodsMachine-pr">
         <dropdownList noSort="true" defaultItem="0" refId="OrgGnomeVinoAuthenticationMethods_setter">Метод:</dropdownList>
-        <checkBox refId="OrgGnomeVinoAuthenticationMethods_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoAuthenticationMethods_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 
@@ -310,7 +376,7 @@
         <textBox refId="OrgGnomeVinoVncPassword_setter">
           <label>Пароль:</label>
         </textBox>
-        <checkBox refId="OrgGnomeVinoVncPassword_setter_blocker">блокировать</checkBox>
+        <checkBox refId="OrgGnomeVinoVncPassword_setter_blocker">Блокировать</checkBox>
         <text>Блокировка изменений данной настройки пользователем. Пользовательские политики для этой настройки будут проигнорированы.</text>
       </presentation>
 


### PR DESCRIPTION
Предложения по файлу ru-RU/basealtgsettings.adml:

1) Замена строк вида:
-Установите правый или нижний цвет... (правый цвет - странно звучит)
Установите цвет правого или нижнего края рабочего стола...

-Количество минут, по истечении которОГО...
Устанавливает количество минут, по истечении которых...

2) Добавлены описания значений и строки типа: "Этот параметр имеет смысл только при активированном параметре «Включение хранителя экрана"

3) В других настройках (например, basealtcontrol) все ключи написаны с прописной буквы: Никогда, Всегда и т.д, а здесь со строчной
(кроме: Время в минутах, Порт, которые написаны с прописной)

По файлу: en-US/basealtgsettings.adml - ключи с прописной.
