### PR TITLE
Ошибка при загрузке шаблонов в gpedit

### DIFF
--- a/en-US/basealt.adml
+++ b/en-US/basealt.adml
@@ -55,7 +55,7 @@
       <string id="ALT_Remote_Access_Vino_Gnome">Remote access via Vino</string>
       <string id="ALT_Remote_Access_Vino_Gnome_Help">Remote access via Vino settings</string>
       <string id="ALT_Windows_Manager_Marco">Windows manager Marco</string>
-      <string id="ALT_ALT_Windows_Manager_Marco_Help">Windows manager Marco settings</string>
+      <string id="ALT_Windows_Manager_Marco_Help">Windows manager Marco settings</string>
       <string id="ALT_Windows_Manager_Marco_Keyboard">Keyboard settings</string>
       <string id="ALT_Windows_Manager_Marco_Keyboard_Help">Keyboard settings</string>
     </stringTable>

--- a/ru-RU/basealtcontrol.adml
+++ b/ru-RU/basealtcontrol.adml
@@ -711,7 +711,7 @@ SSSD — использовать метод проверки подлиннос
 Только root — только суперпользователю (root) разрешено запускать /usr/bin/write
       </string>
       <string id="write_public">Любой пользователь</string>
-      <string id="write_restricted">Только wheel</string>
+      <string id="write_restricted">Только root</string>
 
       <string id="xdg-user-dirs">Стандартные каталоги в home</string>
       <string id="xdg-user-dirs_help">Эта политика определяет, работает ли функция стандартных каталогов(Документы, Загрузки, Изобржения и т.д.) xdg-user-dirs в домашнем каталоге пользователя home


### PR DESCRIPTION
В файлах basealt.admx и basealt.adml (en-US) не соответствуют идентификаторы описания.
Поправил:
ALT_ALT_Windows_Manager_Marco_Help
На:
ALT_Windows_Manager_Marco_Help
