### PR TITLE
Fix same key for different polkit policy items

### DIFF
--- a/BaseALTPolkit.admx
+++ b/BaseALTPolkit.admx
@@ -297,40 +297,6 @@
         presentation="$(presentation.org-freedesktop-udisks2-filesystem-mount-all-pr)">
       <parentCategory ref="system:ALT_Udisks2" />
       <supportedOn ref="system:SUPPORTED_AltP10" />
-         <enabledList defaultKey="Software\BaseALT\Policies\Polkit">
-          <item valueName="org.freedesktop.udisks2.filesystem-mount">
-            <value>
-                <decimal value="2" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-other-seat">
-            <value>
-                <decimal value="2" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-system">
-            <value>
-                <decimal value="2" />
-            </value>
-          </item>
-        </enabledList>
-         <disabledList defaultKey="Software\BaseALT\Policies\Polkit">
-          <item valueName="org.freedesktop.udisks2.filesystem-mount">
-            <value>
-                <decimal value="0" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-other-seat">
-            <value>
-                <decimal value="0" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-system">
-            <value>
-                <decimal value="0" />
-            </value>
-          </item>
-        </disabledList>
       <elements>
         <enum id="OrgFreedesktopUdisks2FileSystemMount_setter" valueName="org.freedesktop.udisks2.filesystem-mount" required="true">
           <item displayName="$(string.org-freedesktop-udisks2-filesystem-mount-No)">
@@ -461,40 +427,6 @@
         presentation="$(presentation.org-freedesktop-udisks2-filesystem-mount-all-user-pr)">
       <parentCategory ref="system:ALT_Udisks2" />
       <supportedOn ref="system:SUPPORTED_AltP10" />
-         <enabledList defaultKey="Software\BaseALT\Policies\Polkit">
-          <item valueName="org.freedesktop.udisks2.filesystem-mount">
-            <value>
-                <decimal value="2" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-other-seat">
-            <value>
-                <decimal value="2" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-system">
-            <value>
-                <decimal value="2" />
-            </value>
-          </item>
-        </enabledList>
-         <disabledList defaultKey="Software\BaseALT\Policies\Polkit">
-          <item valueName="org.freedesktop.udisks2.filesystem-mount">
-            <value>
-                <decimal value="0" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-other-seat">
-            <value>
-                <decimal value="0" />
-            </value>
-          </item>
-          <item valueName="org.freedesktop.udisks2.filesystem-mount-system">
-            <value>
-                <decimal value="0" />
-            </value>
-          </item>
-        </disabledList>
       <elements>
         <enum id="OrgFreedesktopUdisks2FileSystemMount_setter" valueName="org.freedesktop.udisks2.filesystem-mount" required="true">
           <item displayName="$(string.org-freedesktop-udisks2-filesystem-mount-No)">


### PR DESCRIPTION
Machine policy has enabledList element that changes key Software\BaseALT\Policies\Polkit with value
org.freedesktop.udisks2.filesystem-mount
and enum that changes same key and value. There are several such enums, their types (string) differ from types in enabledList (int), so only enums should remain it is impossible to have both at the same time.

